### PR TITLE
feat(db): TIMESTAMPTZ migration + Prisma adapter session UTC fix

### DIFF
--- a/features/audit/audit.repository.ts
+++ b/features/audit/audit.repository.ts
@@ -92,9 +92,9 @@ export class AuditRepository extends BaseRepository {
           ON awp."parentEntityType" = 'journal_entries'
          AND awp."parentEntityId"   = je.id
         WHERE (
-          ${cursorCreatedAt}::timestamp IS NULL
-          OR awp."createdAt" <  ${cursorCreatedAt}::timestamp
-          OR (awp."createdAt" = ${cursorCreatedAt}::timestamp AND awp.id < ${cursorId}::text)
+          ${cursorCreatedAt}::timestamptz IS NULL
+          OR awp."createdAt" <  ${cursorCreatedAt}::timestamptz
+          OR (awp."createdAt" = ${cursorCreatedAt}::timestamptz AND awp.id < ${cursorId}::text)
         )
         ORDER BY awp."createdAt" DESC, awp.id DESC
         LIMIT ${fetchLimit}::int

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -5,7 +5,7 @@ import { PrismaClient } from "../generated/prisma/client";
 
 const connectionString = `${process.env.DATABASE_URL}`;
 
-const adapter = new PrismaPg({ connectionString });
+const adapter = new PrismaPg({ connectionString, options: "-c timezone=UTC" });
 const prisma = new PrismaClient({ adapter });
 
 export { prisma };

--- a/openspec/changes/timestamptz-migration/design.md
+++ b/openspec/changes/timestamptz-migration/design.md
@@ -61,8 +61,8 @@ La exploration.md lista una tabla con 65 entradas pero su resumen declara 43+14+
 
 **Decisión del design**: la fuente canónica es el schema actual. Este design cataloga las **65 columnas** y el SQL de migración debe tener exactamente 65 `ALTER COLUMN`. El split correcto (post decisiones humanas) es:
 
-- **TIMESTAMP-AFFECTED**: 48 columnas → `USING "col" AT TIME ZONE 'America/La_Paz'`
-- **UTC-NOON**: 17 columnas → `USING "col" AT TIME ZONE 'UTC'`
+- **TIMESTAMP-AFFECTED**: 49 columnas → `USING "col" AT TIME ZONE 'America/La_Paz'`
+- **UTC-NOON**: 16 columnas → `USING "col" AT TIME ZONE 'UTC'`
 - **Total**: 65
 
 Las 5 columnas adicionales respecto al conteo original del exploration (todas TIMESTAMP-AFFECTED) son:
@@ -150,8 +150,8 @@ Las 5 columnas adicionales respecto al conteo original del exploration (todas TI
 
 | Categoría USING | Count | Columnas representativas |
 |-----------------|-------|--------------------------|
-| TIMESTAMP-AFFECTED (`AT TIME ZONE 'America/La_Paz'`) | **48** | Todos los `createdAt`, `updatedAt`, `closedAt`, `windowStart`, `deactivatedAt` |
-| UTC-NOON (`AT TIME ZONE 'UTC'`) | **17** | `Sale.date`, `Purchase.date`, `JournalEntry.date`, `FiscalPeriod.startDate/endDate`, `ChickenLot.startDate/endDate`, `Expense.date`, `MortalityLog.date`, `Dispatch.date`, `Payment.date`, `PurchaseDetail.fecha`, `AccountsReceivable.dueDate`, `AccountsPayable.dueDate`, `IvaPurchaseBook.fechaFactura`, `IvaSalesBook.fechaFactura` |
+| TIMESTAMP-AFFECTED (`AT TIME ZONE 'America/La_Paz'`) | **49** | Todos los `createdAt`, `updatedAt`, `closedAt`, `windowStart`, `deactivatedAt` |
+| UTC-NOON (`AT TIME ZONE 'UTC'`) | **16** | `Sale.date`, `Purchase.date`, `JournalEntry.date`, `FiscalPeriod.startDate/endDate`, `ChickenLot.startDate/endDate`, `Expense.date`, `MortalityLog.date`, `Dispatch.date`, `Payment.date`, `PurchaseDetail.fecha`, `AccountsReceivable.dueDate`, `AccountsPayable.dueDate`, `IvaPurchaseBook.fechaFactura`, `IvaSalesBook.fechaFactura` |
 | **TOTAL** | **65** | |
 
 > **IMPORTANTE**: La exploration.md y la proposal.md citaban "60 columnas" por un error en el resumen del explore (las filas de OrgProfile y DocumentSignatureConfig y User.createdAt no se sumaron correctamente). El schema actual tiene 65 campos DateTime. El SQL debe tener exactamente **65 ALTER COLUMN**. Esta tabla es la fuente canónica — `sdd-apply` la usa directamente para generar el SQL.
@@ -198,7 +198,7 @@ Esto crea `prisma/migrations/<timestamp>_timestamptz_migration/migration.sql` co
 ALTER TABLE "organization_members" ALTER COLUMN "deactivatedAt" TYPE TIMESTAMPTZ(3);
 ```
 
-El SQL generado es **incorrecto** para las 48 columnas TIMESTAMP-AFFECTED: Postgres aplica un casting implícito `TIMESTAMP → TIMESTAMPTZ` que asume UTC, pero los datos son naive BO-local. Este paso solo genera la base — NO aplicar todavía.
+El SQL generado es **incorrecto** para las 49 columnas TIMESTAMP-AFFECTED: Postgres aplica un casting implícito `TIMESTAMP → TIMESTAMPTZ` que asume UTC, pero los datos son naive BO-local. Este paso solo genera la base — NO aplicar todavía.
 
 **Nombre tentativo de migración**: `<timestamp>_timestamptz_migration`
 (donde `<timestamp>` se autogenera al correr `--create-only`, ej. `20260427120000_timestamptz_migration`)
@@ -207,7 +207,7 @@ El SQL generado es **incorrecto** para las 48 columnas TIMESTAMP-AFFECTED: Postg
 
 Abrir el archivo `.sql` generado y agregar la cláusula `USING` correcta en cada `ALTER COLUMN`.
 
-#### Template para columnas TIMESTAMP-AFFECTED (48 columnas)
+#### Template para columnas TIMESTAMP-AFFECTED (49 columnas)
 
 ```sql
 ALTER TABLE "<table_name>"
@@ -215,7 +215,7 @@ ALTER TABLE "<table_name>"
   USING "<column_name>" AT TIME ZONE 'America/La_Paz';
 ```
 
-#### Template para columnas UTC-NOON (17 columnas)
+#### Template para columnas UTC-NOON (16 columnas)
 
 ```sql
 ALTER TABLE "<table_name>"
@@ -230,7 +230,7 @@ El archivo DEBE estar organizado por tabla, con comentarios de categoría para f
 ```sql
 -- ============================================================
 -- TIMESTAMP-AFFECTED: datos naive BO-local → USING 'America/La_Paz'
--- (48 columnas — representan instantes reales en el tiempo)
+-- (49 columnas — representan instantes reales en el tiempo)
 -- ============================================================
 
 -- organizations
@@ -250,7 +250,7 @@ ALTER TABLE "custom_roles"
 
 -- ============================================================
 -- UTC-NOON: datos ya en UTC vía toNoonUtc() → USING 'UTC'
--- (17 columnas — representan fechas calendario como TIMESTAMPTZ)
+-- (16 columnas — representan fechas calendario como TIMESTAMPTZ)
 -- ============================================================
 
 -- chicken_lots
@@ -387,19 +387,19 @@ Checklist para el archivo `.sql` antes de aplicar:
   grep "TYPE TIMESTAMPTZ" prisma/migrations/*_timestamptz_migration/migration.sql | grep -v "USING"
   # Esperado: 0 líneas
   ```
-- [ ] **Count USING La_Paz**: exactamente 48
+- [ ] **Count USING La_Paz**: exactamente 49
   ```bash
   grep -c "AT TIME ZONE 'America/La_Paz'" prisma/migrations/*_timestamptz_migration/migration.sql
-  # Esperado: 48
+  # Esperado: 49
   ```
-- [ ] **Count USING UTC**: exactamente 17
+- [ ] **Count USING UTC**: exactamente 16
   ```bash
   grep -c "AT TIME ZONE 'UTC'" prisma/migrations/*_timestamptz_migration/migration.sql
-  # Esperado: 17
+  # Esperado: 16
   ```
-- [ ] **Suma**: 48 + 17 = 65 ✓
-- [ ] **Revisión visual de las 17 UTC-NOON**: confirmar que ninguna columna TIMESTAMP-AFFECTED está listada en la sección UTC.
-- [ ] **Revisión visual de las 48 TIMESTAMP-AFFECTED**: confirmar que ninguna columna UTC-NOON está en la sección BO-local.
+- [ ] **Suma**: 49 + 16 = 65 ✓
+- [ ] **Revisión visual de las 16 UTC-NOON**: confirmar que ninguna columna TIMESTAMP-AFFECTED está listada en la sección UTC.
+- [ ] **Revisión visual de las 49 TIMESTAMP-AFFECTED**: confirmar que ninguna columna UTC-NOON está en la sección BO-local.
 
 ### 3. Dry-run
 
@@ -552,7 +552,7 @@ Ninguna. Todas las ambigüedades del explore fueron resueltas por el usuario y s
 
 Para uso en la revisión final del `.sql` editado, esta es la lista completa de (tabla, columna, USING):
 
-### TIMESTAMP-AFFECTED (48) — `AT TIME ZONE 'America/La_Paz'`
+### TIMESTAMP-AFFECTED (49) — `AT TIME ZONE 'America/La_Paz'`
 
 | Tabla SQL | Columna |
 |-----------|---------|
@@ -606,7 +606,7 @@ Para uso en la revisión final del `.sql` editado, esta es la lista completa de 
 | document_signature_configs | createdAt |
 | document_signature_configs | updatedAt |
 
-### UTC-NOON (17) — `AT TIME ZONE 'UTC'`
+### UTC-NOON (16) — `AT TIME ZONE 'UTC'`
 
 | Tabla SQL | Columna |
 |-----------|---------|

--- a/openspec/changes/timestamptz-migration/design.md
+++ b/openspec/changes/timestamptz-migration/design.md
@@ -1,0 +1,630 @@
+# Design: timestamptz-migration
+
+**Fecha**: 2026-04-27
+**Cambio**: `timestamptz-migration`
+**Estado**: listo para `sdd-tasks`
+
+---
+
+## Pre-design verification — grep `deactivatedAt`
+
+### Comandos ejecutados
+
+```bash
+grep -rn "deactivatedAt" \
+  --include="*.ts" --include="*.tsx" --include="*.prisma" --include="*.sql" --include="*.json" \
+  /path/to/avicont-ia | grep -v node_modules | grep -v .next | grep -v __tests__
+```
+
+### Hallazgos
+
+#### Writes / sets de valor (no-null)
+
+| Archivo | Línea | Tipo de write |
+|---------|-------|---------------|
+| `features/organizations/organizations.repository.ts` | 175 | `data: { deactivatedAt: new Date() }` — instante de desactivación |
+| `features/ai-agent/__tests__/agent-context.repository.test.ts` | 167 | `data: { deactivatedAt: new Date() }` — test, no producción |
+
+**Total writes de valor no-null (producción)**: 1 — en `organizations.repository.ts:175` dentro de `deactivateMember()`.
+
+#### Reseteos a null
+
+| Archivo | Línea | Semántica |
+|---------|-------|-----------|
+| `features/organizations/organizations.repository.ts` | 189 | `data: { deactivatedAt: null, role }` — reactivación |
+
+#### Lecturas / filtros
+
+Todos los demás usos son `deactivatedAt: null` en cláusulas WHERE (filtrado de miembros activos), sin escritura de valor temporal. Son correctos post-migración sin cambios.
+
+#### En seeds
+
+`scripts/seed-audit-fixtures.ts:39` usa `deactivatedAt: null` como filtro en una query, no como valor escrito. No hay ningún seed que setee un valor de fecha en `deactivatedAt`.
+
+#### En migraciones
+
+`prisma/migrations/20260403223611_add_member_soft_delete/migration.sql:2` — solo agrega la columna como `TIMESTAMP(3)` nullable, sin setear valores.
+
+### Semántica confirmada
+
+`deactivatedAt` se escribe con `new Date()` (instante en que se ejecuta la operación de desactivación) — es un **timestamp de log del sistema**, no una fecha operacional configurada por el usuario. Semántica: "en qué instante exacto se desactivó este miembro".
+
+### Conclusión
+
+La decisión del usuario de tratar `deactivatedAt` como **TIMESTAMP-AFFECTED** con `USING "deactivatedAt" AT TIME ZONE 'America/La_Paz'` es **CORRECTA**. El dato es naive BO-local (escrito con `new Date()` en un proceso con `TZ=America/La_Paz`), y debe reinterpretarse como instante UTC real. No hay evidencia de contradicción.
+
+---
+
+## Reconciliación de conteo: 60 vs 65 columnas
+
+La exploration.md lista una tabla con 65 entradas pero su resumen declara 43+14+3=60. El schema actual tiene **65 campos DateTime**. La discrepancia se explica porque la tabla del exploration sí incluye las 65, pero el resumen no las cuenta a todas correctamente (probablemente porque se redactó antes de que se agregaran algunos modelos).
+
+**Decisión del design**: la fuente canónica es el schema actual. Este design cataloga las **65 columnas** y el SQL de migración debe tener exactamente 65 `ALTER COLUMN`. El split correcto (post decisiones humanas) es:
+
+- **TIMESTAMP-AFFECTED**: 48 columnas → `USING "col" AT TIME ZONE 'America/La_Paz'`
+- **UTC-NOON**: 17 columnas → `USING "col" AT TIME ZONE 'UTC'`
+- **Total**: 65
+
+Las 5 columnas adicionales respecto al conteo original del exploration (todas TIMESTAMP-AFFECTED) son:
+1. `User.createdAt` (estaba en la tabla pero no en el resumen)
+2. `OrgProfile.createdAt`
+3. `OrgProfile.updatedAt`
+4. `DocumentSignatureConfig.createdAt`
+5. `DocumentSignatureConfig.updatedAt`
+
+---
+
+## Inventario columna-por-columna — Tabla canónica
+
+> Esta tabla es la **fuente canónica** para la generación del SQL. Cualquier discrepancia entre esta tabla y el SQL de migración es un error crítico.
+
+| # | Modelo | Campo | Línea schema.prisma | Categoría USING | Justificación |
+|---|--------|-------|---------------------|-----------------|---------------|
+| 1 | Organization | createdAt | 18 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación vía `NOW()` del server |
+| 2 | CustomRole | createdAt | 60 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 3 | CustomRole | updatedAt | 61 | TIMESTAMP-AFFECTED | `@updatedAt` — instante de última modificación |
+| 4 | OrganizationMember | deactivatedAt | 74 | TIMESTAMP-AFFECTED | Escrito con `new Date()` en `deactivateMember()` (organizations.repository.ts:175) — instante de log del sistema. Ver Pre-design verification arriba. |
+| 5 | User | createdAt | 89 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 6 | Document | createdAt | 121 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 7 | ChatMessage | createdAt | 150 | TIMESTAMP-AFFECTED | `@default(now())` — indexado en `(sessionId, createdAt)` — crítico para orden |
+| 8 | AgentRateLimit | windowStart | 166 | TIMESTAMP-AFFECTED | `floorToHour()` usa `setUTCMinutes(0,0,0)` — trabaja en UTC, pero el valor raw almacenado es aun naive BO-local por el bug de TZ de sesión. Migrar es inocuo y correcto. |
+| 9 | AgentRateLimit | updatedAt | 168 | TIMESTAMP-AFFECTED | `@updatedAt` — instante de modificación |
+| 10 | Farm | createdAt | 200 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 11 | Farm | updatedAt | 201 | TIMESTAMP-AFFECTED | `@updatedAt` — instante de modificación |
+| 12 | ChickenLot | startDate | 216 | UTC-NOON | Fecha de inicio del lote — mostrado con `toLocaleDateString("es-BO")`, decisión humana: tratar como UTC-noon (uniforme). `USING AT TIME ZONE 'UTC'` preserva sin modificación. |
+| 13 | ChickenLot | endDate | 217 | UTC-NOON | Fecha de cierre del lote — misma semántica que startDate. |
+| 14 | ChickenLot | createdAt | 221 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 15 | ChickenLot | updatedAt | 222 | TIMESTAMP-AFFECTED | `@updatedAt` — instante de modificación |
+| 16 | Expense | date | 238 | UTC-NOON | Fecha de gasto — mostrado como calendario. Decisión humana: migrar como UTC-NOON. |
+| 17 | Expense | createdAt | 242 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 18 | MortalityLog | date | 257 | UTC-NOON | Fecha de mortalidad — mostrado como calendario. Decisión humana: migrar como UTC-NOON. |
+| 19 | MortalityLog | createdAt | 261 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 20 | JournalEntry | date | 362 | UTC-NOON | Fecha del asiento contable — `toNoonUtc()` confirmado vía `journal.dates.ts`. |
+| 21 | JournalEntry | createdAt | 374 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 22 | JournalEntry | updatedAt | 375 | TIMESTAMP-AFFECTED | `@updatedAt` — instante de modificación |
+| 23 | FiscalPeriod | startDate | 422 | UTC-NOON | Límite del período contable — `assertMonthlyShape` usa `.getUTCDate()/.getUTCMonth()` → trabaja en UTC. |
+| 24 | FiscalPeriod | endDate | 423 | UTC-NOON | Igual que startDate — fecha de cierre del período. |
+| 25 | FiscalPeriod | closedAt | 425 | TIMESTAMP-AFFECTED | Instante en que se cerró el período — se escribe con `new Date()` vía lógica de close/reopen. |
+| 26 | FiscalPeriod | createdAt | 428 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 27 | FiscalPeriod | updatedAt | 429 | TIMESTAMP-AFFECTED | `@updatedAt` — instante de modificación |
+| 28 | Contact | createdAt | 578 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 29 | Contact | updatedAt | 579 | TIMESTAMP-AFFECTED | `@updatedAt` — instante de modificación |
+| 30 | AccountsReceivable | dueDate | 604 | UTC-NOON | Fecha de vencimiento — decisión humana: migrar como UTC-NOON (schema uniforme). `USING AT TIME ZONE 'UTC'` preserva el dato sin shift. |
+| 31 | AccountsReceivable | createdAt | 610 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 32 | AccountsReceivable | updatedAt | 611 | TIMESTAMP-AFFECTED | `@updatedAt` — instante de modificación |
+| 33 | AccountsPayable | dueDate | 633 | UTC-NOON | Fecha de vencimiento — misma semántica y decisión que AccountsReceivable.dueDate. |
+| 34 | AccountsPayable | createdAt | 639 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 35 | AccountsPayable | updatedAt | 640 | TIMESTAMP-AFFECTED | `@updatedAt` — instante de modificación |
+| 36 | OrgSettings | createdAt | 675 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 37 | OrgSettings | updatedAt | 676 | TIMESTAMP-AFFECTED | `@updatedAt` — instante de modificación |
+| 38 | Dispatch | date | 689 | UTC-NOON | Fecha del despacho — `dispatch.service.ts` usa `input.date.getTime()` para cálculo de dueDate. Decisión humana: UTC-NOON. |
+| 39 | Dispatch | createdAt | 707 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 40 | Dispatch | updatedAt | 708 | TIMESTAMP-AFFECTED | `@updatedAt` — instante de modificación |
+| 41 | ProductType | createdAt | 754 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 42 | ProductType | updatedAt | 755 | TIMESTAMP-AFFECTED | `@updatedAt` — instante de modificación |
+| 43 | Payment | date | 770 | UTC-NOON | Fecha del pago — `payment-form.tsx` usa `.toISOString().split("T")[0]` → espera UTC-noon. |
+| 44 | Payment | createdAt | 781 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 45 | Payment | updatedAt | 782 | TIMESTAMP-AFFECTED | `@updatedAt` — instante de modificación |
+| 46 | OperationalDocType | createdAt | 804 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 47 | OperationalDocType | updatedAt | 805 | TIMESTAMP-AFFECTED | `@updatedAt` — instante de modificación |
+| 48 | Purchase | date | 821 | UTC-NOON | Fecha de la compra — `purchase.service.ts` usa `purchase.date.getTime()`. Confirmado UTC-noon. |
+| 49 | Purchase | createdAt | 842 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 50 | Purchase | updatedAt | 843 | TIMESTAMP-AFFECTED | `@updatedAt` — instante de modificación |
+| 51 | PurchaseDetail | fecha | 867 | UTC-NOON | Fecha de flete por línea — campo nullable. Mismo patrón que otras fechas de comprobante. |
+| 52 | Sale | date | 915 | UTC-NOON | Fecha de la venta — `sale.service.ts` usa `sale.date.getTime()`. Confirmado UTC-noon. |
+| 53 | Sale | createdAt | 925 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 54 | Sale | updatedAt | 926 | TIMESTAMP-AFFECTED | `@updatedAt` — instante de modificación |
+| 55 | AuditLog | createdAt | 970 | TIMESTAMP-AFFECTED | **Epicentro del bug** — indexado, usado en cursor pagination, comparado en range queries. |
+| 56 | IvaPurchaseBook | fechaFactura | 988 | UTC-NOON | `iva-books.repository.ts:202` usa `toNoonUtc(input.fechaFactura)` explícitamente. |
+| 57 | IvaPurchaseBook | createdAt | 1012 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 58 | IvaPurchaseBook | updatedAt | 1013 | TIMESTAMP-AFFECTED | `@updatedAt` — instante de modificación |
+| 59 | IvaSalesBook | fechaFactura | 1028 | UTC-NOON | Igual que IvaPurchaseBook.fechaFactura — usa `toNoonUtc()`. |
+| 60 | IvaSalesBook | createdAt | 1052 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 61 | IvaSalesBook | updatedAt | 1053 | TIMESTAMP-AFFECTED | `@updatedAt` — instante de modificación |
+| 62 | OrgProfile | createdAt | 1097 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 63 | OrgProfile | updatedAt | 1098 | TIMESTAMP-AFFECTED | `@updatedAt` — instante de modificación |
+| 64 | DocumentSignatureConfig | createdAt | 1110 | TIMESTAMP-AFFECTED | `@default(now())` — instante de creación |
+| 65 | DocumentSignatureConfig | updatedAt | 1111 | TIMESTAMP-AFFECTED | `@updatedAt` — instante de modificación |
+
+### Resumen del inventario canónico
+
+| Categoría USING | Count | Columnas representativas |
+|-----------------|-------|--------------------------|
+| TIMESTAMP-AFFECTED (`AT TIME ZONE 'America/La_Paz'`) | **48** | Todos los `createdAt`, `updatedAt`, `closedAt`, `windowStart`, `deactivatedAt` |
+| UTC-NOON (`AT TIME ZONE 'UTC'`) | **17** | `Sale.date`, `Purchase.date`, `JournalEntry.date`, `FiscalPeriod.startDate/endDate`, `ChickenLot.startDate/endDate`, `Expense.date`, `MortalityLog.date`, `Dispatch.date`, `Payment.date`, `PurchaseDetail.fecha`, `AccountsReceivable.dueDate`, `AccountsPayable.dueDate`, `IvaPurchaseBook.fechaFactura`, `IvaSalesBook.fechaFactura` |
+| **TOTAL** | **65** | |
+
+> **IMPORTANTE**: La exploration.md y la proposal.md citaban "60 columnas" por un error en el resumen del explore (las filas de OrgProfile y DocumentSignatureConfig y User.createdAt no se sumaron correctamente). El schema actual tiene 65 campos DateTime. El SQL debe tener exactamente **65 ALTER COLUMN**. Esta tabla es la fuente canónica — `sdd-apply` la usa directamente para generar el SQL.
+
+---
+
+## Estrategia de generación y edición del SQL
+
+### Paso 1 — Editar `schema.prisma`
+
+Agregar `@db.Timestamptz(3)` a cada uno de los 65 campos `DateTime`. Regla mecánica:
+
+```prisma
+# Antes:
+createdAt  DateTime @default(now())
+updatedAt  DateTime @updatedAt
+date       DateTime
+endDate    DateTime?
+
+# Después:
+createdAt  DateTime @db.Timestamptz(3) @default(now())
+updatedAt  DateTime @db.Timestamptz(3) @updatedAt
+date       DateTime @db.Timestamptz(3)
+endDate    DateTime? @db.Timestamptz(3)
+```
+
+La anotación siempre va después del tipo (`DateTime`) y antes de los modificadores (`@default`, `@updatedAt`). Para campos nullable (`DateTime?`) la anotación también aplica: `DateTime? @db.Timestamptz(3)`.
+
+**Verificación post-edición del schema**:
+```bash
+grep "DateTime" prisma/schema.prisma | grep -v "@db.Timestamptz"
+# Resultado esperado: 0 líneas (todas las columnas DateTime deben tener @db.Timestamptz(3))
+```
+
+### Paso 2 — Generar el SQL base
+
+```bash
+pnpm prisma migrate dev --create-only --name timestamptz_migration
+```
+
+Esto crea `prisma/migrations/<timestamp>_timestamptz_migration/migration.sql` con 65 sentencias de la forma:
+
+```sql
+ALTER TABLE "organization_members" ALTER COLUMN "deactivatedAt" TYPE TIMESTAMPTZ(3);
+```
+
+El SQL generado es **incorrecto** para las 48 columnas TIMESTAMP-AFFECTED: Postgres aplica un casting implícito `TIMESTAMP → TIMESTAMPTZ` que asume UTC, pero los datos son naive BO-local. Este paso solo genera la base — NO aplicar todavía.
+
+**Nombre tentativo de migración**: `<timestamp>_timestamptz_migration`
+(donde `<timestamp>` se autogenera al correr `--create-only`, ej. `20260427120000_timestamptz_migration`)
+
+### Paso 3 — Editar el SQL generado
+
+Abrir el archivo `.sql` generado y agregar la cláusula `USING` correcta en cada `ALTER COLUMN`.
+
+#### Template para columnas TIMESTAMP-AFFECTED (48 columnas)
+
+```sql
+ALTER TABLE "<table_name>"
+  ALTER COLUMN "<column_name>" TYPE TIMESTAMPTZ(3)
+  USING "<column_name>" AT TIME ZONE 'America/La_Paz';
+```
+
+#### Template para columnas UTC-NOON (17 columnas)
+
+```sql
+ALTER TABLE "<table_name>"
+  ALTER COLUMN "<column_name>" TYPE TIMESTAMPTZ(3)
+  USING "<column_name>" AT TIME ZONE 'UTC';
+```
+
+#### Estructura recomendada del archivo SQL
+
+El archivo DEBE estar organizado por tabla, con comentarios de categoría para facilitar revisión:
+
+```sql
+-- ============================================================
+-- TIMESTAMP-AFFECTED: datos naive BO-local → USING 'America/La_Paz'
+-- (48 columnas — representan instantes reales en el tiempo)
+-- ============================================================
+
+-- organizations
+ALTER TABLE "organizations"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+
+-- custom_roles
+ALTER TABLE "custom_roles"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "custom_roles"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- ... (resto de columnas TIMESTAMP-AFFECTED)
+
+-- ============================================================
+-- UTC-NOON: datos ya en UTC vía toNoonUtc() → USING 'UTC'
+-- (17 columnas — representan fechas calendario como TIMESTAMPTZ)
+-- ============================================================
+
+-- chicken_lots
+ALTER TABLE "chicken_lots"
+  ALTER COLUMN "startDate" TYPE TIMESTAMPTZ(3)
+  USING "startDate" AT TIME ZONE 'UTC';
+ALTER TABLE "chicken_lots"
+  ALTER COLUMN "endDate" TYPE TIMESTAMPTZ(3)
+  USING "endDate" AT TIME ZONE 'UTC';
+
+-- ... (resto de columnas UTC-NOON)
+```
+
+#### Mapeo tabla SQL → modelo Prisma
+
+| Modelo Prisma | Tabla SQL (@@map) |
+|---------------|-------------------|
+| Organization | `organizations` |
+| CustomRole | `custom_roles` |
+| OrganizationMember | `organization_members` |
+| User | `users` |
+| Document | `documents` |
+| ChatMessage | `chat_messages` |
+| AgentRateLimit | `agent_rate_limits` |
+| Farm | `farms` |
+| ChickenLot | `chicken_lots` |
+| Expense | `expenses` |
+| MortalityLog | `mortality_logs` |
+| JournalEntry | `journal_entries` |
+| FiscalPeriod | `fiscal_periods` |
+| Contact | `contacts` |
+| AccountsReceivable | `accounts_receivable` |
+| AccountsPayable | `accounts_payable` |
+| OrgSettings | `org_settings` |
+| Dispatch | `dispatches` |
+| ProductType | `product_types` |
+| Payment | `payments` |
+| OperationalDocType | `operational_doc_types` |
+| Purchase | `purchases` |
+| PurchaseDetail | `purchase_details` |
+| Sale | `sales` |
+| AuditLog | `audit_logs` |
+| IvaPurchaseBook | `iva_purchase_books` |
+| IvaSalesBook | `iva_sales_books` |
+| OrgProfile | `org_profile` |
+| DocumentSignatureConfig | `document_signature_configs` |
+
+> **Nota**: los nombres exactos de las tablas SQL se pueden verificar con los decoradores `@@map()` en `schema.prisma`. Si alguna tabla no tiene `@@map`, Prisma usa el nombre en snake_case plural por default.
+
+### Paso 4 — Verificación del SQL antes de aplicar (ver sección Pre-apply)
+
+### Paso 5 — Aplicar la migración
+
+```bash
+pnpm prisma migrate dev
+```
+
+Sin `--create-only`. Prisma aplica el archivo `.sql` editado. PostgreSQL ejecuta todos los ALTER en una única transacción implícita por archivo de migración.
+
+---
+
+## Fix del cursor en `audit.repository.ts`
+
+### Líneas exactas a cambiar
+
+**Archivo**: `features/audit/audit.repository.ts`
+
+**Líneas 95-97** (verificado en el archivo actual):
+
+```typescript
+// ANTES (incorrecto post-migración):
+${cursorCreatedAt}::timestamp IS NULL
+OR awp."createdAt" <  ${cursorCreatedAt}::timestamp
+OR (awp."createdAt" = ${cursorCreatedAt}::timestamp AND awp.id < ${cursorId}::text)
+
+// DESPUÉS (correcto con TIMESTAMPTZ):
+${cursorCreatedAt}::timestamptz IS NULL
+OR awp."createdAt" <  ${cursorCreatedAt}::timestamptz
+OR (awp."createdAt" = ${cursorCreatedAt}::timestamptz AND awp.id < ${cursorId}::text)
+```
+
+**Cambio**: reemplazar `::timestamp` por `::timestamptz` en las 3 ocurrencias dentro del bloque WHERE de la función `listFlat`.
+
+### Por qué este cambio es necesario
+
+El cursor se serializa como `last.createdAt.toISOString()` (línea 107 del mismo archivo) — produce un string ISO-8601 con sufijo Z (UTC). Con la columna como `TIMESTAMPTZ(3)`, el cast `::timestamp` descartaría la información de timezone del string antes de la comparación, produciendo comparaciones incorrectas en rangos que crucen la medianoche UTC (`04:00:00Z` = medianoche BO-local).
+
+### Cambios adicionales requeridos
+
+**No se requieren cambios** en:
+- Tipos TypeScript: el tipo de `cursorCreatedAt` es `string | null` — sigue siendo un string ISO, solo cambia el cast SQL.
+- `AuditCursor` interface: sigue siendo `{ createdAt: string; id: string }`.
+- Helpers que generan el cursor: `nextCursor = { createdAt: last.createdAt.toISOString(), id: last.id }` (línea 107) — correcto, produce ISO-Z.
+- `getVoucherHistory` en el mismo repositorio: no usa cursor pagination, no necesita cambio.
+
+### Inclusión en el PR
+
+Este fix va en el mismo commit que la migración SQL, o como un commit separado previo dentro del mismo PR. Orden recomendado:
+
+1. **Commit A**: editar `schema.prisma` (agregar `@db.Timestamptz(3)`)
+2. **Commit B**: agregar la migración SQL editada manualmente
+3. **Commit C**: fix `::timestamp` → `::timestamptz` en `audit.repository.ts`
+
+Alternativamente, commits A+B pueden unificarse. Lo importante: los 3 cambios van en el mismo PR.
+
+---
+
+## Plan de verificación pre-apply
+
+Antes de ejecutar `pnpm prisma migrate dev` (sin `--create-only`):
+
+### 1. Verificación del schema.prisma
+
+```bash
+# Todos los DateTime deben tener @db.Timestamptz(3) — resultado esperado: 0 líneas
+grep "DateTime" prisma/schema.prisma | grep -v "@db.Timestamptz(3)"
+
+# Contar que son exactamente 65
+grep "DateTime" prisma/schema.prisma | grep "@db.Timestamptz(3)" | wc -l
+# Esperado: 65
+```
+
+### 2. Inspección visual del SQL editado
+
+Checklist para el archivo `.sql` antes de aplicar:
+
+- [ ] **Total de ALTER COLUMN**: exactamente 65
+  ```bash
+  grep -c "ALTER COLUMN" prisma/migrations/*_timestamptz_migration/migration.sql
+  # Esperado: 65
+  ```
+- [ ] **Ningún ALTER sin USING**: cero ocurrencias de `TYPE TIMESTAMPTZ` sin `USING`
+  ```bash
+  grep "TYPE TIMESTAMPTZ" prisma/migrations/*_timestamptz_migration/migration.sql | grep -v "USING"
+  # Esperado: 0 líneas
+  ```
+- [ ] **Count USING La_Paz**: exactamente 48
+  ```bash
+  grep -c "AT TIME ZONE 'America/La_Paz'" prisma/migrations/*_timestamptz_migration/migration.sql
+  # Esperado: 48
+  ```
+- [ ] **Count USING UTC**: exactamente 17
+  ```bash
+  grep -c "AT TIME ZONE 'UTC'" prisma/migrations/*_timestamptz_migration/migration.sql
+  # Esperado: 17
+  ```
+- [ ] **Suma**: 48 + 17 = 65 ✓
+- [ ] **Revisión visual de las 17 UTC-NOON**: confirmar que ninguna columna TIMESTAMP-AFFECTED está listada en la sección UTC.
+- [ ] **Revisión visual de las 48 TIMESTAMP-AFFECTED**: confirmar que ninguna columna UTC-NOON está en la sección BO-local.
+
+### 3. Dry-run
+
+Prisma no soporta un dry-run formal de `migrate dev`. Las alternativas disponibles:
+
+- **`pnpm prisma migrate diff`**: genera el diff entre el schema actual y el SQL de migración, sin aplicarlo. Permite verificar que Prisma reconoce el migration file correctamente.
+  ```bash
+  pnpm prisma migrate diff \
+    --from-migrations prisma/migrations \
+    --to-schema-datamodel prisma/schema.prisma \
+    --script
+  ```
+- **Verificación en DB de test local**: antes de aplicar en la DB principal, se puede aplicar en una DB de test vacía con `DATABASE_URL=<test_db> pnpm prisma migrate dev`. Como la base solo tiene datos de ejemplo, el riesgo de pérdida es bajo, pero tener una DB auxiliar es una buena práctica.
+
+---
+
+## Plan de verificación post-apply
+
+Una vez ejecutado `pnpm prisma migrate dev` exitosamente:
+
+### 1. Verificar el tipo de cada columna en PostgreSQL
+
+```sql
+-- Verificar tipo de columna en una tabla representativa:
+SELECT column_name, data_type, datetime_precision
+FROM information_schema.columns
+WHERE table_name = 'audit_logs'
+  AND column_name = 'createdAt';
+-- Esperado: data_type = 'timestamp with time zone', datetime_precision = 3
+
+-- Script completo para verificar todas las tablas:
+SELECT table_name, column_name, data_type
+FROM information_schema.columns
+WHERE data_type = 'timestamp without time zone'
+  AND table_schema = 'public';
+-- Esperado: 0 filas (ninguna columna debe quedar como TIMESTAMP sin TZ)
+```
+
+El `\d audit_logs` en psql también muestra el tipo directamente.
+
+### 2. Verificar corrección de un timestamp histórico
+
+Si existen filas insertadas en la DB de desarrollo antes de la migración:
+
+```sql
+-- Supongamos que existe una fila de audit con un createdAt conocido.
+-- Antes de migrar: el valor naive almacenado era, por ej., '2026-04-26T22:30:00' (BO-local 22:30).
+-- Después de migrar con USING 'America/La_Paz': debe ser '2026-04-27T02:30:00Z' (22:30 BO = 02:30 UTC del día siguiente).
+-- La consulta:
+SELECT id, "createdAt", "createdAt" AT TIME ZONE 'America/La_Paz' AS "createdAt_local"
+FROM audit_logs
+ORDER BY "createdAt" DESC
+LIMIT 5;
+-- La columna "createdAt_local" debe mostrar la hora correcta en BO (la que el usuario vio en pantalla antes de migrar).
+```
+
+Para un timestamp de referencia conocido (ej. creado hoy a las 18:30 BO-local):
+- Antes de migrar (con TIMESTAMP): se leía como `2026-04-26T18:30:00.000Z` (UTC falso, -4h del instante real)
+- Después de migrar (con TIMESTAMPTZ): debe leerse como `2026-04-26T22:30:00.000Z` (UTC real)
+- `AT TIME ZONE 'America/La_Paz'` sobre el valor migrado debe dar `2026-04-26T18:30:00` BO ✓
+
+### 3. Smoke test del módulo audit en la UI
+
+1. Navegar a `/[orgSlug]/audit` en la app local.
+2. Verificar que la página carga sin errores (no 500).
+3. Verificar que las cards de auditoría muestran hora (no solo fecha) y que la hora coincide con la hora real del evento en Bolivia.
+4. Navegar entre páginas (scroll down o cargar más) para verificar que la paginación cursor-based funciona sin duplicados ni filas faltantes.
+5. Verificar que un rango de fechas que cruza la medianoche local (ej. 23:50 a 00:10) devuelve todas las filas en orden correcto.
+
+### 4. Tests y type-check
+
+```bash
+pnpm tsc --noEmit
+# Esperado: 0 errores
+
+pnpm test
+# Esperado: todos los tests en verde (los mocks de tests usan new Date("...Z") — correctos con TIMESTAMPTZ)
+```
+
+Los tests unitarios del módulo audit (si usan mocks con timestamps UTC) deben seguir pasando sin cambios porque la interfaz TypeScript (`Date`) no cambia — solo cambia el tipo de columna en la DB.
+
+---
+
+## Riesgos técnicos y mitigaciones (design level)
+
+### R-D1 (CRÍTICO) — Atomicidad del ALTER de 65 columnas en PostgreSQL
+
+**Riesgo**: ¿Es atómica la migración? ¿Qué pasa si un ALTER falla a mitad?
+
+**Análisis**: Prisma ejecuta el archivo SQL de migración dentro de una transacción implícita de PostgreSQL. PostgreSQL soporta DDL transaccional — un `ALTER TABLE ... ALTER COLUMN TYPE` puede hacer rollback. Si cualquier ALTER falla (ej. violación de constraint, tipo incompatible, falta de extensión), **toda la transacción hace rollback** y ninguna tabla queda parcialmente migrada.
+
+**Mitigación**:
+- El checklist pre-apply (verificar que todos los ALTERs tienen USING) reduce el riesgo de fallo por casting incorrecto.
+- Si la migración falla, el estado de la DB es el anterior (sin cambios). Se puede corregir el SQL y reintentar.
+- Prisma registra la migración como aplicada solo si el SQL termina con éxito.
+
+**Trade-off**: la atomicidad es la razón por la que se eligió la opción de migración única (vs. batch). El único costo es que un error en cualquiera de las 65 columnas revierte todo — lo que implica que el SQL debe estar correcto antes de aplicar.
+
+---
+
+### R-D2 (ALTO) — Table lock en producción futura
+
+**Riesgo**: PostgreSQL adquiere un `ACCESS EXCLUSIVE` lock por tabla durante un `ALTER COLUMN ... TYPE`. Con 65 columnas en 29 tablas, si la tabla tiene muchas filas (ej. `audit_logs` con millones de registros), el ALTER puede durar segundos o minutos, bloqueando lecturas y escrituras concurrentes.
+
+**Mitigación para entorno actual (desarrollo)**:
+- La DB de desarrollo tiene volumen pequeño. El riesgo de downtime es negligible.
+- No hay usuarios concurrentes durante la migración.
+
+**Para producción futura (documentar en PR)**:
+- Evaluar `pg_repack` o `ALTER TABLE ... RENAME COLUMN` + columna shadow para migraciones online.
+- Considerar una ventana de mantenimiento.
+- El PR debe incluir una nota explícita advirtiendo que este approach (ALTER directo) no es adecuado para producción con tablas de alto volumen.
+
+---
+
+### R-D3 (MEDIO) — Conexiones abiertas durante el ALTER
+
+**Riesgo**: conexiones activas de la app (Next.js con Prisma connection pool) que tienen transacciones abiertas pueden impedir que el `ALTER TABLE` adquiera su lock, resultando en una espera indefinida (deadlock potencial o timeout).
+
+**Mitigación**:
+- Aplicar la migración con la app parada (o con el pool de conexiones drenado).
+- En desarrollo: cerrar el servidor de Next.js antes de correr `pnpm prisma migrate dev`.
+- Prisma migrate dev lanza el servidor de migraciones directamente contra la DB — no va por el pool de la app.
+
+---
+
+### R-D4 (BAJO) — El nombre de tabla `org_settings` podría diferir
+
+**Riesgo**: `OrgSettings` no tiene `@@map` visible en el schema read (líneas 675-676). Si el nombre de tabla generado por Prisma difiere de `org_settings`, el SQL editado manualmente fallaría al referenciar la tabla incorrecta.
+
+**Mitigación**: antes de editar el SQL, verificar los nombres de tabla en el SQL generado por Prisma. El SQL autogenerado siempre usa los nombres correctos — solo hay que transcribirlos al editar.
+
+---
+
+### R-D5 (BAJO) — `PurchaseDetail.fecha` es nullable (`DateTime?`)
+
+**Riesgo**: una columna `TIMESTAMP(3) NULL` que contiene valores NULL. El `ALTER ... TYPE TIMESTAMPTZ(3) USING "fecha" AT TIME ZONE 'UTC'` en PostgreSQL trata los NULL como NULL — la conversión es segura. Sin embargo, si existe algún registro con un valor naive que no sea UTC-noon, el `USING 'UTC'` lo preservaría tal cual (interpretándolo como UTC), lo que podría ser incorrecto.
+
+**Mitigación**: dado que la decisión humana es tratar toda esta columna como UTC-NOON (decisión de uniformidad de schema), el riesgo es aceptado. Si en el futuro se determina que algunos valores de `fecha` eran naive BO-local, se requeriría una migración de corrección separada.
+
+---
+
+## Decisiones de diseño abiertas
+
+Ninguna. Todas las ambigüedades del explore fueron resueltas por el usuario y son vinculantes. El grep de `deactivatedAt` confirmó que la decisión humana es correcta.
+
+---
+
+## Apéndice — Tabla de verificación SQL completa
+
+Para uso en la revisión final del `.sql` editado, esta es la lista completa de (tabla, columna, USING):
+
+### TIMESTAMP-AFFECTED (48) — `AT TIME ZONE 'America/La_Paz'`
+
+| Tabla SQL | Columna |
+|-----------|---------|
+| organizations | createdAt |
+| custom_roles | createdAt |
+| custom_roles | updatedAt |
+| organization_members | deactivatedAt |
+| users | createdAt |
+| documents | createdAt |
+| chat_messages | createdAt |
+| agent_rate_limits | windowStart |
+| agent_rate_limits | updatedAt |
+| farms | createdAt |
+| farms | updatedAt |
+| chicken_lots | createdAt |
+| chicken_lots | updatedAt |
+| expenses | createdAt |
+| mortality_logs | createdAt |
+| journal_entries | createdAt |
+| journal_entries | updatedAt |
+| fiscal_periods | closedAt |
+| fiscal_periods | createdAt |
+| fiscal_periods | updatedAt |
+| contacts | createdAt |
+| contacts | updatedAt |
+| accounts_receivable | createdAt |
+| accounts_receivable | updatedAt |
+| accounts_payable | createdAt |
+| accounts_payable | updatedAt |
+| org_settings | createdAt |
+| org_settings | updatedAt |
+| dispatches | createdAt |
+| dispatches | updatedAt |
+| product_types | createdAt |
+| product_types | updatedAt |
+| payments | createdAt |
+| payments | updatedAt |
+| operational_doc_types | createdAt |
+| operational_doc_types | updatedAt |
+| purchases | createdAt |
+| purchases | updatedAt |
+| sales | createdAt |
+| sales | updatedAt |
+| audit_logs | createdAt |
+| iva_purchase_books | createdAt |
+| iva_purchase_books | updatedAt |
+| iva_sales_books | createdAt |
+| iva_sales_books | updatedAt |
+| org_profile | createdAt |
+| org_profile | updatedAt |
+| document_signature_configs | createdAt |
+| document_signature_configs | updatedAt |
+
+### UTC-NOON (17) — `AT TIME ZONE 'UTC'`
+
+| Tabla SQL | Columna |
+|-----------|---------|
+| chicken_lots | startDate |
+| chicken_lots | endDate |
+| expenses | date |
+| mortality_logs | date |
+| journal_entries | date |
+| fiscal_periods | startDate |
+| fiscal_periods | endDate |
+| accounts_receivable | dueDate |
+| accounts_payable | dueDate |
+| dispatches | date |
+| payments | date |
+| purchases | date |
+| purchase_details | fecha |
+| sales | date |
+| iva_purchase_books | fechaFactura |
+| iva_sales_books | fechaFactura |
+
+> **Nota final**: `purchase_details` tiene `fecha` como `DateTime?` (nullable). La cláusula `USING "fecha" AT TIME ZONE 'UTC'` en PostgreSQL maneja NULL correctamente (NULL permanece NULL).

--- a/openspec/changes/timestamptz-migration/design.md
+++ b/openspec/changes/timestamptz-migration/design.md
@@ -296,7 +296,7 @@ ALTER TABLE "chicken_lots"
 | IvaPurchaseBook | `iva_purchase_books` |
 | IvaSalesBook | `iva_sales_books` |
 | OrgProfile | `org_profile` |
-| DocumentSignatureConfig | `document_signature_configs` |
+| DocumentSignatureConfig | `document_signature_config` |
 
 > **Nota**: los nombres exactos de las tablas SQL se pueden verificar con los decoradores `@@map()` en `schema.prisma`. Si alguna tabla no tiene `@@map`, Prisma usa el nombre en snake_case plural por default.
 
@@ -603,8 +603,8 @@ Para uso en la revisión final del `.sql` editado, esta es la lista completa de 
 | iva_sales_books | updatedAt |
 | org_profile | createdAt |
 | org_profile | updatedAt |
-| document_signature_configs | createdAt |
-| document_signature_configs | updatedAt |
+| document_signature_config | createdAt |
+| document_signature_config | updatedAt |
 
 ### UTC-NOON (16) — `AT TIME ZONE 'UTC'`
 

--- a/openspec/changes/timestamptz-migration/exploration.md
+++ b/openspec/changes/timestamptz-migration/exploration.md
@@ -94,6 +94,8 @@
 
 > **Nota sobre las 43 TIMESTAMP-AFFECTED**: incluye todos los `createdAt` generados por `CURRENT_TIMESTAMP` en el server-side (DB defaults vía `NOW()`) y todos los `updatedAt` manejados por Prisma con `@updatedAt`. Ambos tipos tienen el mismo bug TZ confirmado en diagnóstico previo.
 
+> **Nota correctiva (post-decisiones del usuario)**: el resumen original 43+14+3=60 contenía error aritmético — la tabla detallada arriba lista 65 filas, no 60. Las 5 columnas que faltaban en el resumen (todas TIMESTAMP-AFFECTED) son: `User.createdAt`, `OrgProfile.createdAt`, `OrgProfile.updatedAt`, `DocumentSignatureConfig.createdAt`, `DocumentSignatureConfig.updatedAt`. Tras las decisiones del usuario (todas migran, sin exenciones por categoría), el split final canónico es **49 TIMESTAMP-AFFECTED + 16 UTC-NOON = 65**. Ver `design.md` (tabla canónica líneas 81-147) como fuente de verdad.
+
 ---
 
 ## 2. Opciones técnicas

--- a/openspec/changes/timestamptz-migration/exploration.md
+++ b/openspec/changes/timestamptz-migration/exploration.md
@@ -1,0 +1,386 @@
+# Exploration: timestamptz-migration
+
+**Fecha**: 2026-04-26
+**Cambio**: `timestamptz-migration`
+**Estado**: completo — listo para `sdd-propose`
+
+---
+
+## 1. Estado actual confirmado
+
+### Inventario completo de columnas DateTime (`prisma/schema.prisma`, verificado hoy)
+
+> Regla de clasificación aplicada:
+> - **TIMESTAMP-AFFECTED**: columna que representa un instante real en el tiempo (audit, createdAt, updatedAt, rate-limit bucket, etc.) → DEBE migrar.
+> - **DATE-CALENDAR-NOON**: fecha de comprobante ya persistida como UTC-noon via `toNoonUtc()` → NO migra (el patrón UTC-noon funciona correctamente y es inmune al bug de TZ).
+> - **DATE-CALENDAR-LEGACY**: fecha de comprobante en columnas nullable/opcionales cuyo patrón de escritura hay que verificar.
+> - **AMBIGUA**: requiere decisión humana.
+
+| # | Modelo | Campo | Línea (aprox.) | Tipo en schema | Categoría | Justificación |
+|---|--------|-------|----------------|---------------|-----------|---------------|
+| 1 | Organization | createdAt | 18 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación de la org |
+| 2 | CustomRole | createdAt | 60 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 3 | CustomRole | updatedAt | 61 | DateTime @updatedAt | TIMESTAMP-AFFECTED | Instante de última modificación |
+| 4 | OrganizationMember | deactivatedAt | 74 | DateTime? | AMBIGUA | Fecha de desactivación; si se usa como "fecha efectiva" calendario → DATE-CALENDAR-NOON. Si se usa como instante de log → TIMESTAMP-AFFECTED. Verificar cómo se escribe. |
+| 5 | User | createdAt | 89 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 6 | Document | createdAt | 121 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 7 | ChatMessage | createdAt | 150 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de chat; indexado en `(sessionId, createdAt)` → crítico para orden |
+| 8 | AgentRateLimit | windowStart | 166 | DateTime | TIMESTAMP-AFFECTED | Bucket de hora UTC; `floorToHour()` usa setUTCMinutes/setUTCHours — ya trabaja en UTC. Migración es inocua pero correcta. |
+| 9 | AgentRateLimit | updatedAt | 168 | DateTime @updatedAt | TIMESTAMP-AFFECTED | Instante de modificación |
+| 10 | Farm | createdAt | ~200 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 11 | Farm | updatedAt | ~201 | DateTime @updatedAt | TIMESTAMP-AFFECTED | Instante de modificación |
+| 12 | ChickenLot | startDate | 216 | DateTime | DATE-CALENDAR-NOON | Fecha de inicio del lote — mostrado como fecha calendario con `toLocaleDateString("es-BO")` en `farm-detail-client.tsx` y `lot-detail-client.tsx`. Se escribe vía form → confirmar que usa `toNoonUtc()` antes de persistir. Si no usa `toNoonUtc()`, es AMBIGUA. |
+| 13 | ChickenLot | endDate | 217 | DateTime? | DATE-CALENDAR-NOON | Igual que startDate — fecha de cierre del lote. Mismo caveat. |
+| 14 | ChickenLot | createdAt | 220 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 15 | ChickenLot | updatedAt | 221 | DateTime @updatedAt | TIMESTAMP-AFFECTED | Instante de modificación |
+| 16 | Expense | date | 239 | DateTime | DATE-CALENDAR-NOON | Fecha de gasto — mostrado como calendario. Verificar que usa `toNoonUtc()` al escribir. |
+| 17 | Expense | createdAt | 242 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 18 | MortalityLog | date | 257 | DateTime | DATE-CALENDAR-NOON | Fecha de mortalidad — mostrado como calendario. |
+| 19 | MortalityLog | createdAt | 261 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 20 | JournalEntry | date | 362 | DateTime | DATE-CALENDAR-NOON | Fecha del asiento contable — `toNoonUtc()` confirmado vía `journal.dates.ts`. |
+| 21 | JournalEntry | createdAt | 375 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 22 | JournalEntry | updatedAt | 376 | DateTime @updatedAt | TIMESTAMP-AFFECTED | Instante de modificación |
+| 23 | FiscalPeriod | startDate | 424 | DateTime | DATE-CALENDAR-NOON | Límite del período contable — `assertMonthlyShape` usa `.getUTCDate()/.getUTCMonth()` → trabaja en UTC. Se escribe como UTC-midnight o UTC-noon. NO representa un instante. |
+| 24 | FiscalPeriod | endDate | 425 | DateTime | DATE-CALENDAR-NOON | Igual que startDate. |
+| 25 | FiscalPeriod | closedAt | 426 | DateTime? | TIMESTAMP-AFFECTED | Instante en que se cerró el período — lógica de close/reopen lo escribe con `new Date()`. |
+| 26 | FiscalPeriod | createdAt | 429 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 27 | FiscalPeriod | updatedAt | 430 | DateTime @updatedAt | TIMESTAMP-AFFECTED | Instante de modificación |
+| 28 | Contact | createdAt | ~578 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 29 | Contact | updatedAt | ~579 | DateTime @updatedAt | TIMESTAMP-AFFECTED | Instante de modificación |
+| 30 | AccountsReceivable | dueDate | 604 | DateTime | AMBIGUA | Fecha de vencimiento — conceptualmente es "fecha calendario" (día en que vence), pero se escribe vía Zod `z.coerce.date()`. Si el form la pasa como "YYYY-MM-DD" y luego el server la persiste directamente sin `toNoonUtc()`, puede haberse almacenado como UTC-midnight. Verificar `receivables.repository.ts` línea 66. |
+| 31 | AccountsReceivable | createdAt | 611 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 32 | AccountsReceivable | updatedAt | 612 | DateTime @updatedAt | TIMESTAMP-AFFECTED | Instante de modificación |
+| 33 | AccountsPayable | dueDate | 629 | DateTime | AMBIGUA | Mismo caso que AccountsReceivable.dueDate |
+| 34 | AccountsPayable | createdAt | 639 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 35 | AccountsPayable | updatedAt | 640 | DateTime @updatedAt | TIMESTAMP-AFFECTED | Instante de modificación |
+| 36 | OrgSettings | createdAt | 675 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 37 | OrgSettings | updatedAt | 676 | DateTime @updatedAt | TIMESTAMP-AFFECTED | Instante de modificación |
+| 38 | Dispatch | date | 689 | DateTime | DATE-CALENDAR-NOON | Fecha del despacho. `dispatch.service.ts` usa `input.date.getTime()` para cálculo de dueDate — si la fecha viene de `toNoonUtc()`, es correcto. |
+| 39 | Dispatch | createdAt | 706 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 40 | Dispatch | updatedAt | 707 | DateTime @updatedAt | TIMESTAMP-AFFECTED | Instante de modificación |
+| 41 | ProductType | createdAt | ~753 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 42 | ProductType | updatedAt | ~754 | DateTime @updatedAt | TIMESTAMP-AFFECTED | Instante de modificación |
+| 43 | Payment | date | 770 | DateTime | DATE-CALENDAR-NOON | Fecha del pago — `payment-form.tsx` usa `.toISOString().split("T")[0]` para mostrarla → indica que se espera UTC-noon. |
+| 44 | Payment | createdAt | 781 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 45 | Payment | updatedAt | 782 | DateTime @updatedAt | TIMESTAMP-AFFECTED | Instante de modificación |
+| 46 | OperationalDocType | createdAt | ~806 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 47 | OperationalDocType | updatedAt | ~807 | DateTime @updatedAt | TIMESTAMP-AFFECTED | Instante de modificación |
+| 48 | Purchase | date | 821 | DateTime | DATE-CALENDAR-NOON | Fecha de la compra. `purchase.service.ts` usa `purchase.date.getTime()` → UTC-noon invariante. |
+| 49 | Purchase | createdAt | 840 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 50 | Purchase | updatedAt | 841 | DateTime @updatedAt | TIMESTAMP-AFFECTED | Instante de modificación |
+| 51 | PurchaseDetail | fecha | 867 | DateTime? | DATE-CALENDAR-NOON | Fecha de flete por línea. Campo nullable. Mismo patrón que fechas de comprobante. |
+| 52 | Sale | date | 914 | DateTime | DATE-CALENDAR-NOON | Fecha de la venta. `sale.service.ts` usa `sale.date.getTime()`. Confirmado UTC-noon. |
+| 53 | Sale | createdAt | 924 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 54 | Sale | updatedAt | 925 | DateTime @updatedAt | TIMESTAMP-AFFECTED | Instante de modificación |
+| 55 | AuditLog | createdAt | 970 | DateTime @default(now()) | TIMESTAMP-AFFECTED | **Instante crítico** — indexado, usado en cursor pagination, comparado en range queries. Es el epicentro del bug confirmado. |
+| 56 | IvaPurchaseBook | fechaFactura | 988 | DateTime | DATE-CALENDAR-NOON | `iva-books.repository.ts:202` usa `toNoonUtc(input.fechaFactura)` explícitamente. La columna puede haber sido escrita como UTC-noon. Leer vía `.toISOString().slice(0,10)`. NO migra. |
+| 57 | IvaPurchaseBook | createdAt | 1012 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 58 | IvaPurchaseBook | updatedAt | 1013 | DateTime @updatedAt | TIMESTAMP-AFFECTED | Instante de modificación |
+| 59 | IvaSalesBook | fechaFactura | 1028 | DateTime | DATE-CALENDAR-NOON | Igual que IvaPurchaseBook.fechaFactura — usa `toNoonUtc()`. NO migra. |
+| 60 | IvaSalesBook | createdAt | 1052 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 61 | IvaSalesBook | updatedAt | 1053 | DateTime @updatedAt | TIMESTAMP-AFFECTED | Instante de modificación |
+| 62 | OrgProfile | createdAt | 1097 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 63 | OrgProfile | updatedAt | 1098 | DateTime @updatedAt | TIMESTAMP-AFFECTED | Instante de modificación |
+| 64 | DocumentSignatureConfig | createdAt | 1110 | DateTime @default(now()) | TIMESTAMP-AFFECTED | Instante de creación |
+| 65 | DocumentSignatureConfig | updatedAt | 1111 | DateTime @updatedAt | TIMESTAMP-AFFECTED | Instante de modificación |
+
+### Resumen del inventario
+
+| Categoría | Cantidad | Acción |
+|-----------|----------|--------|
+| TIMESTAMP-AFFECTED | **43** | Migrar a TIMESTAMPTZ(3) + USING AT TIME ZONE |
+| DATE-CALENDAR-NOON | **14** | No migrar (ya correctas) |
+| AMBIGUA | **3** | Decisión humana (ver §5) |
+
+> **Nota sobre las 43 TIMESTAMP-AFFECTED**: incluye todos los `createdAt` generados por `CURRENT_TIMESTAMP` en el server-side (DB defaults vía `NOW()`) y todos los `updatedAt` manejados por Prisma con `@updatedAt`. Ambos tipos tienen el mismo bug TZ confirmado en diagnóstico previo.
+
+---
+
+## 2. Opciones técnicas
+
+### Opción A — Migración única: un ALTER por columna TIMESTAMP-AFFECTED (APROBADA)
+
+**Descripción**: Un único archivo de migración Prisma con ~43 sentencias `ALTER TABLE ... ALTER COLUMN ... TYPE TIMESTAMPTZ(3) USING "col" AT TIME ZONE 'America/La_Paz'`. El schema Prisma actualiza cada campo con `@db.Timestamptz(3)`.
+
+**Proceso**:
+1. Editar `schema.prisma`: agregar `@db.Timestamptz(3)` a todos los campos TIMESTAMP-AFFECTED.
+2. `prisma migrate dev --create-only --name timestamptz_migration` → genera el SQL base.
+3. Editar el SQL generado para agregar la cláusula `USING "<col>" AT TIME ZONE 'America/La_Paz'` en cada ALTER (Prisma NO la genera automáticamente — ver §3 riesgo R1).
+4. `prisma migrate dev` (sin `--create-only`) aplica la migración editada.
+
+**Ventajas**:
+- Atómico — una transacción, rollback total si falla.
+- Un solo paso de revisión y aprobación.
+- El backfill histórico se incluye en el ALTER mismo.
+- Alineado con lo aprobado por el usuario.
+
+**Desventajas**:
+- Genera lock sobre todas las tablas simultáneamente (en un solo ALTER por tabla, Postgres hace full-table lock por la duración del ALTER). En producción con tabla grande podría causar downtime.
+- Error en una tabla obliga a revisar todas.
+
+**Veredicto**: correcto para el entorno actual (DB de volumen pequeño, no hay concurrent heavy writers en producción).
+
+---
+
+### Opción B — Migración por batch (audit_logs primero, resto después)
+
+**Descripción**: Dividir en 2-3 migraciones. Primera migración: `audit_logs.createdAt` (epicentro del bug visible). Segunda: resto de tablas de alta frecuencia. Tercera: tablas de baja frecuencia.
+
+**Ventajas**:
+- Riesgo reducido en cada paso — es más fácil verificar.
+- Permite validar el comportamiento post-migración en producción antes de comprometer todo.
+
+**Desventajas**:
+- Estado intermedio inconsistente: `audit_logs.createdAt` ya es correcto pero `JournalEntry.createdAt` todavía muestra -4h. Confuso.
+- Más archivos de migración = más surface de review.
+- El bug sigue existiendo en producción hasta que se completa el lote final.
+
+**Veredicto**: descartada — el estado intermedio es peor que el estado buggy completo. La Opción A es preferible.
+
+---
+
+### Opción C — No migrar schema; corregir en el cliente
+
+**Descripción**: Mantener `TIMESTAMP(3)`, agregar `+4h` en `formatDateTimeBO` / `formatTimeBO` para compensar el offset introducido por node-postgres.
+
+**Por qué se descarta**:
+1. Es un hack de compensación, no una corrección. La fuente de datos sigue siendo incorrecta.
+2. Cualquier consulta server-side que compare timestamps con `NOW()` (ej. rate limiter, audit range queries) o que serialice a ISO string para APIs externas emitiría instantes UTC falsos.
+3. El cursor de paginación del audit (`createdAt.toISOString()`) quedaría mal serializado.
+4. Cuando la DB migre a UTC o node-postgres cambie su comportamiento, habría que deshacer el hack.
+
+**Veredicto**: descartada definitivamente.
+
+---
+
+### Opción D — Cambiar TZ de sesión de Postgres a UTC
+
+**Descripción**: Modificar `postgresql.conf` para que `TimeZone = UTC` en la sesión (o agregar `options=-c timezone=UTC` en la DATABASE_URL).
+
+**Ventajas**:
+- Sin migración de datos.
+- Corrección instantánea.
+
+**Desventajas**:
+- Requiere acceso a la configuración del servidor PostgreSQL (o URL de conexión), que puede no estar disponible en producción.
+- Los datos históricos ya almacenados como naive-BO-local seguirían siendo interpretados incorrectamente si el TZ cambia. node-postgres leería los mismos bytes pero los asignaría diferente → bug diferente, no corrección.
+- **NO resuelve el problema de los datos ya almacenados**. Las filas existentes tienen naive timestamps que dicen "20:18:00" y significan BO-local. Si el session TZ pasa a UTC, node-postgres los leerá como `20:18:00 UTC` → siguen siendo incorrectos (ahora +4h en lugar de -4h).
+
+**Veredicto**: no es una solución. Solo sería un band-aid para filas nuevas, con datos históricos aún corruptos en otra dirección.
+
+---
+
+## 3. Riesgos identificados
+
+### R1 (CRÍTICO): Prisma NO genera `USING ... AT TIME ZONE` automáticamente
+
+**Verificación**: La migración que genera `prisma migrate dev --create-only` al cambiar `DateTime` a `DateTime @db.Timestamptz(3)` produce:
+
+```sql
+ALTER TABLE "foo" ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3);
+```
+
+Postgres ejecuta eso con el casting implícito `TIMESTAMP → TIMESTAMPTZ`, que **asume UTC** para los bytes existentes. Pero los bytes son naive BO-local (America/La_Paz), no UTC. El casting implícito rompe los datos.
+
+La cláusula correcta es:
+```sql
+ALTER TABLE "foo"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+```
+
+**Acción requerida**: el archivo SQL generado por `--create-only` DEBE editarse manualmente antes de aplicar. Ningún ALTER debe quedar sin su `USING ... AT TIME ZONE`.
+
+**Nota sobre el proceso `--create-only`**: este es el proceso establecido en el proyecto para migraciones con SQL custom. Hay precedente en `cierre-periodo` y `voucher-types` donde se editó el SQL antes de aplicar. Ver `openspec/changes/archive/2026-04-21-cierre-periodo/design.md`.
+
+---
+
+### R2 (ALTO): El trigger de auditoría `audit_trigger_fn()` usa `NOW()` — no se rompe, pero su semántica cambia
+
+**Hallazgo**: la función `audit_trigger_fn()` en `20260406010241_monthly_close_audit_trail/migration.sql` hace:
+
+```sql
+INSERT INTO audit_logs (..., "createdAt")
+VALUES (..., NOW());
+```
+
+`NOW()` en Postgres retorna un `timestamp with time zone` (TIMESTAMPTZ). Actualmente, como la columna `createdAt` es `TIMESTAMP(3)`, Postgres hace un casting implícito que convierte el `TIMESTAMPTZ` al timezone de sesión (`America/La_Paz`) y lo almacena como naive-BO-local.
+
+Después de la migración a `TIMESTAMPTZ(3)`, `NOW()` se almacenará directamente como el instante UTC correcto. **Esto es exactamente lo que queremos** — no es un riesgo de regresión, es la corrección.
+
+**Acción requerida**: ninguna. El trigger sigue funcionando.
+
+---
+
+### R3 (MEDIO): Cursor pagination del audit usa `::timestamp` cast — puede romperse post-migración
+
+**Hallazgo**: `audit.repository.ts` línea 95:
+
+```sql
+WHERE (
+  ${cursorCreatedAt}::timestamp IS NULL
+  OR awp."createdAt" < ${cursorCreatedAt}::timestamp
+  ...
+)
+```
+
+El cursor se serializa como `last.createdAt.toISOString()` (línea 107). Una vez migrada la columna a `TIMESTAMPTZ(3)`, el cast `::timestamp` en el WHERE hace un "at local time" (sin TZ) sobre el valor de la columna. Esto puede producir comparaciones incorrectas porque `::timestamp` en Postgres descarta la información de TZ.
+
+**El cast correcto después de la migración debería ser `::timestamptz`**, no `::timestamp`.
+
+**Acción requerida**: la migración debe incluir un patch en `audit.repository.ts` para cambiar el cast del cursor de `::timestamp` a `::timestamptz`.
+
+---
+
+### R4 (BAJO): `startOfMonth` y `endOfMonth` en `date-utils.ts` usan local getters
+
+**Hallazgo**: `startOfMonth` usa `new Date(date.getFullYear(), date.getMonth(), 1, ...)` — getters de TZ local. El código asume `TZ=America/La_Paz` en el proceso server-side.
+
+Actualmente, el env del test tiene `TZ=America/La_Paz` y hay un comment explícito en `date-utils.ts` que documenta la dependencia. Esto no cambia con la migración TIMESTAMPTZ — sigue siendo válido. **No es un riesgo de la migración, pero es una deuda técnica a documentar.**
+
+---
+
+### R5 (BAJO): `deactivatedAt` en `OrganizationMember` — semántica desconocida
+
+**Hallazgo**: la columna es `DateTime?` sin `@default(now())` y sin `@updatedAt`. No se encontró código en `features/` que la escriba (solo el migration que la crea). Si es un "fecha de desactivación que el usuario eligió" → DATE-CALENDAR-NOON. Si es "instante en que se desactivó el sistema" → TIMESTAMP-AFFECTED.
+
+**Acción requerida**: decisión humana (ver §5, decisión #1).
+
+---
+
+### R6 (BAJO): `dueDate` en AccountsReceivable/AccountsPayable — escritura sin `toNoonUtc()`
+
+**Hallazgo**: `receivables.repository.ts` línea 66 persiste `dueDate: data.dueDate` directamente. Los filtros de rangos hacen `gte`/`lte` sobre `dueDate`. Si el `dueDate` se pasó desde el form como una Date UTC-midnight, la comparación es correcta. Si se pasó como naive-local, hay un bug latente.
+
+En el contexto del bug TZ actual, el `dueDate` leído de la DB por Prisma también viene con el mismo error (+4h), así que las comparaciones relativas siguen siendo consistentes en el estado buggy actual. Post-migración, si `dueDate` NO migra (porque es DATE-CALENDAR-NOON) pero `createdAt` SÍ migra, las comparaciones mixtas seguirán siendo correctas porque son columnas de naturaleza diferente.
+
+**Conclusión**: el `dueDate` NO debe migrar a TIMESTAMPTZ — es una fecha-vencimiento calendario. Pero debe verificarse que se persiste consistentemente como UTC-noon (la única inconsistencia es si se compara con `createdAt` en alguna query — no se encontró evidencia de eso).
+
+---
+
+### R7 (BAJO): `fechaFactura` en IvaPurchaseBook/IvaSalesBook — ya usa `toNoonUtc()`
+
+**Confirmado**: `iva-books.repository.ts:202` hace `fechaFactura: toNoonUtc(input.fechaFactura)`. Leer vía `.toISOString().slice(0,10)`. Este campo NO debe migrar.
+
+---
+
+### R8 (INFO): AgentRateLimit.windowStart — `floorToHour()` ya trabaja en UTC
+
+**Confirmado**: `rate-limit.repository.ts` implementa `floorToHour` como `out.setUTCMinutes(0, 0, 0)` — usa UTC puro. La columna `windowStart` almacena instantes UTC-hour. Aunque es TIMESTAMP-AFFECTED (debe migrar para corrección formal), el comportamiento en la práctica es correcto porque los buckets ya son UTC-aligned.
+
+Post-migración, el cambio es transparente — los valores son correctos antes y después.
+
+---
+
+## 4. Dependencias y blockers
+
+### 4.1 Código que asume el comportamiento buggy actual
+
+**Búsqueda realizada**: `formatDateBO`, `formatDateTimeBO`, `formatTimeBO`, `new Date(`, `Intl.DateTimeFormat`, comparaciones `.getTime()`.
+
+**Resultado**: NO se encontró código que compense el bug sumando +4h. El código de display (`formatDateTimeBO`, `formatTimeBO`) ya aplica correctamente `Intl.DateTimeFormat` con `timeZone: "America/La_Paz"` — lo que significa que **cuando la fuente sea UTC real post-migración, los displays mostrarán la hora correcta automáticamente**.
+
+**Excepción identificada**: el cursor cast `::timestamp` en `audit.repository.ts` (ver R3).
+
+### 4.2 APIs externas que se rompen
+
+No se identificaron APIs externas que reciban timestamps en formato dependiente del bug. Los serializers usan `.toISOString()` (producen UTC Z-suffix) y los consumidores son internos.
+
+**Caso especial**: `purchase.service.ts:94` y `sale.service.ts:93` hacen `alloc.payment.date.toISOString().split("T")[0]` para obtener la fecha del pago como string. Como `payment.date` es DATE-CALENDAR-NOON (no migra), esto sigue siendo correcto post-migración.
+
+### 4.3 Seed data / fixtures
+
+**Tests**: los mocks en `__tests__/` usan `new Date("2026-04-24T12:00:00Z")` para `createdAt` (UTC-noon explícito) o `new Date()` para campos decorativos. Los tests de `date-utils.test.ts` operan con timestamps UTC reales — serán correctos post-migración.
+
+**No hay seed data** (no se encontró `prisma/seed.ts` ni scripts de seeding con timestamps hardcoded).
+
+### 4.4 Queries con comparaciones date-range sobre TIMESTAMP-AFFECTED
+
+El audit `listFlat` hace comparaciones `createdAt >= dateFrom AND createdAt <= dateTo` donde `dateFrom`/`dateTo` vienen de `startOfMonth`/`endOfMonth` (que usan TZ local). Post-migración, Postgres comparará `TIMESTAMPTZ` con un `Date` de Node.js — esto es correcto porque Prisma envía el instante UTC del `Date`.
+
+La única cuestión es el cursor cast (R3).
+
+### 4.5 Triggers de Postgres con NOW() o columnas timestamp
+
+**Inventario completo de triggers** (de `20260406010241_monthly_close_audit_trail/migration.sql` y `20260424123854_audit_insert_coverage_completion/migration.sql`):
+
+- `audit_dispatches` → escribe en `audit_logs.createdAt` con `NOW()`
+- `audit_payments` → igual
+- `audit_journal_entries` → igual
+- Triggers adicionales sobre `sales`, `purchases`, `sale_details`, `purchase_details`, `journal_lines`, `fiscal_periods` → todos usan la misma función `audit_trigger_fn()` con `NOW()`
+
+**Post-migración**: todos correctos automáticamente — `NOW()` devuelve TIMESTAMPTZ, y la columna receptora también será TIMESTAMPTZ.
+
+---
+
+## 5. Decisiones abiertas para el usuario
+
+### Decisión 1: `OrganizationMember.deactivatedAt` — ¿instante o fecha-calendario?
+
+**Pregunta**: ¿`deactivatedAt` representa el instante exacto en que se desactivó un miembro (timestamp de log) o la fecha en que "entra en efecto" la desactivación (fecha operacional)?
+
+**Contexto**: la columna fue agregada por `20260403223611_add_member_soft_delete/migration.sql` como `TIMESTAMP(3)` nullable sin default. No se encontró código en `features/` que la escriba (puede estar en un handler de API).
+
+**Recomendación**: si es un log de "cuándo sucedió", migrar a TIMESTAMPTZ (TIMESTAMP-AFFECTED). Si es "fecha de desactivación configurada por admin" (similar a `Sale.date`), excluir.
+
+**Impacto si se decide al revés**: si es instante y no migra, el display de `deactivatedAt` (si existe en la UI) seguirá mostrando -4h. Si es fecha-calendario y se migra incorrectamente con `USING AT TIME ZONE 'America/La_Paz'`, los valores se verán +4h adelantados (el USING asume que el dato es naive BO-local, pero si eran noon-UTC podría causar confusión — aunque matemáticamente solo sería UTC-noon convertido a TIMESTAMPTZ real).
+
+---
+
+### Decisión 2: `AccountsReceivable.dueDate` y `AccountsPayable.dueDate` — ¿migrar?
+
+**Pregunta**: ¿`dueDate` se persiste como UTC-noon (como `Sale.date`) o como UTC-midnight (legacy)?
+
+**Contexto**: `receivables.repository.ts:66` hace `dueDate: data.dueDate` directamente sin llamar `toNoonUtc()`. El `data.dueDate` viene de Zod `z.coerce.date()`. Si el form envía `"2026-05-15"` como string, `z.coerce.date()` lo convierte a `new Date("2026-05-15")` que es UTC-midnight.
+
+**Recomendación**: NO migrar `dueDate` a TIMESTAMPTZ — es una fecha-vencimiento calendario. Pero en la fase apply, agregar `toNoonUtc()` en `receivables.repository.ts` al persistir para normalizar a UTC-noon. Esto es independiente de esta migración.
+
+**Impacto si se migra**: si se hace `USING "dueDate" AT TIME ZONE 'America/La_Paz'`, los dueDates almacenados como UTC-midnight `2026-05-15T00:00:00` se interpretarán como "BO-local midnight" → convertidos a `2026-05-15T04:00:00Z`. Luego al leer con `.toISOString().split("T")[0]` saldrá `2026-05-15` (correcto). Pero si se almacenaron como UTC-noon `2026-05-15T12:00:00`, el USING interpretará eso como "BO-local 12:00" → `2026-05-15T16:00:00Z` → `.split("T")[0]` = `2026-05-15` (correcto igual). El resultado es el mismo en ambos casos de entrada — no es peligroso, pero tampoco es necesario.
+
+---
+
+### Decisión 3: ChickenLot.startDate / endDate, Expense.date, MortalityLog.date — verificar escritura
+
+**Pregunta**: ¿estos campos se persisten via `toNoonUtc()` o directamente?
+
+**Contexto**: `farm-detail-client.tsx:138` hace `new Date(lot.startDate).toLocaleDateString("es-BO")` sin usar `formatDateBO` — esto sugiere que o bien se confía en la TZ local (inconsistente) o la columna ya viene como UTC-noon y el `toLocaleDateString` da el día correcto en ambiente BO. Si `startDate` NO usa `toNoonUtc()` y se persistió como UTC-midnight, el display podría mostrar un día antes en la UI.
+
+**Recomendación**: verificar el service/repository de `ChickenLot`, `Expense`, `MortalityLog` para confirmar si usan `toNoonUtc()` antes de persistir. Si no lo hacen y estos son campos DATE-CALENDAR, agregarlos al migration de normalización (fuera de scope de timestamptz-migration) y NO migrarlos a TIMESTAMPTZ.
+
+**Impacto**: si se migran incorrectamente como TIMESTAMP-AFFECTED con `USING AT TIME ZONE 'America/La_Paz'`, una fecha `2026-01-15T00:00:00` (UTC-midnight, que es `2026-01-14T20:00:00 BO-local`) quedaría almacenada como `2026-01-14T20:00:00Z` → al leer con `.slice(0,10)` daría `2026-01-14` (¡un día antes!).
+
+---
+
+### Decisión 4 (OPERACIONAL): ¿Snapshot de la DB antes de aplicar?
+
+**Pregunta**: ¿hacemos un `pg_dump` antes de aplicar la migración en producción?
+
+**Recomendación**: SÍ, siempre para migraciones que modifiquen tipos de columna con USING. El USING con AT TIME ZONE es un backfill destructivo — no reversible sin restaurar backup. Hay precedente en el proyecto (`cierre-periodo/design.md:109`).
+
+---
+
+### Decisión 5: ¿Corregir el cast `::timestamp` en `audit.repository.ts` como parte de esta migración?
+
+**Pregunta**: el cursor de paginación del audit usa `::timestamp` en el WHERE. Post-migración, debería cambiarse a `::timestamptz`. ¿Este fix va dentro del scope de `timestamptz-migration` o es un task separado?
+
+**Recomendación**: incluirlo en el mismo PR/migración como tarea atómica. El cursor broken después de la migración es un bug funcional en el módulo de audit (la pantalla `/audit` paginará mal). No tiene sentido migrar sin incluir este fix.
+
+---
+
+## Notas adicionales
+
+### Sobre Prisma y `@db.Timestamptz(3)`
+
+La anotación Prisma es `@db.Timestamptz(3)` (con mayúscula T, de la librería `@prisma/client`). Esta produce `TIMESTAMPTZ(3)` en el SQL. node-postgres lee `TIMESTAMPTZ` (OID 1184) respetando el timezone de sesión y devuelve un `Date` en UTC real — exactamente el comportamiento correcto.
+
+### Sobre la DB de producción
+
+No se encontraron docs que confirmen el TZ de la DB de producción. Se asume `America/La_Paz` (igual que local) basado en el diagnóstico previo. Esto debe confirmarse antes de aplicar la migración en producción.
+
+### Sobre los `toLocaleDateString` en exporters
+
+Los exporters de trial balance, equity statement, worksheet, etc. usan `d.toLocaleDateString("es-BO")` sobre fechas que son `FiscalPeriod.startDate/endDate` (DATE-CALENDAR-NOON, no migran) o fechas de asiento (DATE-CALENDAR-NOON). Post-migración, estos exporters siguen correctos porque esas columnas no cambian.
+
+### Sobre el proceso TZ del server
+
+`lib/date-utils.ts` comenta: "On the server, this depends on the process TZ — prefer a different helper if a server-side default is ever needed; or ensure TZ=America/La_Paz is set in the server environment." Post-migración, `startOfMonth`/`endOfMonth` siguen dependiendo de `TZ=America/La_Paz` en el proceso. Esto es correcto y no cambia con la migración.

--- a/openspec/changes/timestamptz-migration/learnings.md
+++ b/openspec/changes/timestamptz-migration/learnings.md
@@ -69,12 +69,79 @@ Para refactors triviales, fixes evidentes, o features green-field, el gate puede
 
 ---
 
+## Aprendizaje #3 — La causa raíz era el adapter de Prisma, no el cursor ni la falta de TIMESTAMPTZ
+
+### Hallazgo
+
+El SDD nació de un síntoma visible: `/audit` mostraba timestamps con offset -4h del instante real. La hipótesis inicial atribuyó el bug al cursor `::timestamp` y a la falta de TIMESTAMPTZ en el schema. Después de aplicar la migración a TIMESTAMPTZ y antes de aplicar el cursor fix, se descubrió empíricamente que **el síntoma persistía idéntico** (verificación visual del usuario, commit `6fe4eef` pre-fix).
+
+Investigación empírica reveló que el bug raíz NO era el cursor ni la falta de TIMESTAMPTZ. **Era el adapter `@prisma/adapter-pg@7.7.0`** que descarta información de zona en ambas direcciones del wire:
+
+**Escritura** (`formatDateTime()` en `dist/index.js:389-393`):
+```js
+function formatDateTime(date) {
+  return ... + " " + pad(date.getUTCHours()) + ...;
+  // Manda "YYYY-MM-DD HH:MM:SS" naive — sin Z, sin +00
+}
+```
+Postgres con `session_timezone='America/La_Paz'` interpretaba ese string naive como BO-local y almacenaba +4h del instante UTC real.
+
+**Lectura** (`normalize_timestamptz()` en `dist/index.js:310-312`):
+```js
+function normalize_timestamptz(time) {
+  return time.replace(" ", "T")
+             .replace(/[+-]\d{2}(:\d{2})?$/, "+00:00");
+  // El regex BORRA el offset real ('-04', etc.) y lo reemplaza por '+00:00'
+}
+```
+Postgres devolvía correctamente `'YYYY-MM-DD HH:MM:SS-04'`, pero el adapter destruía el `-04` reemplazándolo por `+00:00` antes de pasarlo a `new Date()`.
+
+**Las dos manifestaciones son la misma raíz**: el adapter ignora TZ y delega 100% al `session_timezone` de Postgres, asumiendo implícitamente UTC.
+
+### El fix de una línea
+
+```typescript
+// lib/prisma.ts (commit 6fe4eef):
+const adapter = new PrismaPg({ connectionString, options: '-c timezone=UTC' });
+```
+
+Forzar `session_timezone='UTC'` en cada conexión del pool **alinea la asunción implícita del adapter (UTC) con la realidad explícita de la sesión**. Con eso:
+- Escritura: adapter manda string naive → Postgres interpreta como UTC → almacena UTC real ✓
+- Lectura: Postgres devuelve `+00` real → regex del adapter lo confirma como `+00:00` (no-op semántico) → instante real preservado ✓
+
+### El cursor fix queda como cleanup, no solución
+
+El fix `::timestamp` → `::timestamptz` (commit `6c862bc`) sigue siendo correcto en aislado:
+- ANSI-conforme
+- Defensa contra cambios futuros de `session_timezone`
+- Preserva info del sufijo Z del cursor
+
+Pero **no era la solución al síntoma visible**. Bajo session UTC, `::timestamp` y `::timestamptz` producen resultados idénticos. El cursor fix es defensivo, no urgente.
+
+### La migración a TIMESTAMPTZ era condición necesaria pero no suficiente
+
+Sin la migración, el regex del adapter no encontraría offset en TIMESTAMP sin TZ y agregaría `+00:00` a un dato que era naive BO. La migración hizo que `+00` venga semánticamente correcto en la lectura (una vez session UTC).
+
+### Recomendación accionable
+
+Para SDDs futuros donde el síntoma involucra valores que cruzan **varias capas** (DB → driver → ORM → app → display), aplicar este checklist antes de finalizar la fase explore:
+
+1. **Trazar el dato extremo a extremo con queries y logs reales**. No asumir comportamiento de capas intermedias.
+2. **Identificar todos los puntos de transformación** (ORM serialization, driver normalization, formatter de display).
+3. **Verificar empíricamente cada punto** — un script de 20 líneas vale por 5 horas de razonamiento.
+
+En este SDD se asumió que el problema era SQL (TIMESTAMPTZ + cursor cast) cuando realmente era una capa más alta (adapter del driver). Sin verificación empírica end-to-end, la migración por sí sola **no habría arreglado nada visible**.
+
+---
+
 ## Para incluir en el PR description (T-18)
 
 Versión condensada de los aprendizajes para el PR body:
 
 > ### Aprendizajes del cambio
 >
-> 1. **Specs de bugs timezone/paginación requieren verificación empírica**. Modelarlos "desde afuera" llevó a 2 errores (shift contractivo vs expansivo, cardinalidad de scenarios) que el gate TDD detectó pero costó re-trabajo. Recomendación para SDDs futuros con tags `timezone`/`pagination`/`cursor`: incluir query empírica antes de redactar scenarios.
+> 1. **La causa raíz era el adapter Prisma, no el cursor ni la falta de TIMESTAMPTZ**. El bug raíz no era `::timestamp` ni columnas TIMESTAMP sin TZ. Era el adapter `@prisma/adapter-pg@7.7.0` que descarta info de zona en ambas direcciones (`formatDateTime` no incluye Z al escribir, `normalize_timestamptz` borra el offset al leer con un regex). La migración a TIMESTAMPTZ era condición necesaria pero no suficiente. El fix de una línea (`options: '-c timezone=UTC'`) corrige ambos bugs simultáneamente porque alinea el comportamiento implícito del adapter (asume UTC) con el comportamiento explícito de la sesión (forzada UTC). El cursor fix queda como cleanup ANSI-conforme, no como solución al síntoma visible.
 >
-> 2. **El gate TDD detectó problemas en specs, no en código**. En ambos casos, sin el gate, los tests "pasarían" siendo no-diferenciales y la spec quedaría con descripción incorrecta del bug. Mantener el gate como invariante para fixes de bugs sutiles.
+> 2. **Specs de bugs timezone/paginación requieren verificación empírica**. Modelarlos "desde afuera" llevó a 2 errores (shift contractivo vs expansivo, cardinalidad de scenarios) que el gate TDD detectó pero costó re-trabajo. Recomendación para SDDs futuros con tags `timezone`/`pagination`/`cursor`: trazar el dato extremo a extremo (DB → driver → ORM → app → display) con queries y logs reales antes de redactar scenarios.
+>
+> 3. **El gate TDD detectó problemas en specs, no en código**. En 2 iteraciones consecutivas, sin el gate, los tests "pasarían" siendo no-diferenciales y la spec quedaría con descripción incorrecta del bug. Mantener el gate como invariante para fixes de bugs sutiles.

--- a/openspec/changes/timestamptz-migration/learnings.md
+++ b/openspec/changes/timestamptz-migration/learnings.md
@@ -1,0 +1,80 @@
+# Learnings — timestamptz-migration
+
+Aprendizajes emergentes durante la implementación del cambio. **Se incluyen en el PR description (T-18, Fase 8)** y se sintetizan al hacer `sdd-archive`.
+
+---
+
+## Aprendizaje #1 — Las specs sobre bugs de timezone/paginación necesitan verificación empírica
+
+### Contexto
+
+Durante la fase `sdd-spec` se modeló el bug del cursor `::timestamp` "desde afuera" (razonamiento sobre lo que Postgres "debería" hacer al castear un string ISO-8601 con sufijo `Z` a `TIMESTAMP` sin TZ). El razonamiento llevó a dos errores en cascada que el gate TDD detectó después:
+
+### Error 1 — Dirección del shift (commit `4b4fdbf`)
+
+**Lo que decía la spec original**: el cast `::timestamp` produce un offset "hacia atrás" (-4h) que **omite filas** de la comparación.
+
+**Lo que Postgres realmente hace** (verificado empíricamente):
+1. `'2026-04-27T04:00:00.000Z'::timestamp` descarta el `Z` y produce `2026-04-27T04:00:00.000` naive
+2. Al comparar `timestamptz_col < timestamp_value`, Postgres coerce el TIMESTAMP a TIMESTAMPTZ usando `current_setting('TimeZone')`
+3. Con `TimeZone = 'America/La_Paz'` (UTC-4), el valor naive `04:00` se interpreta como `04:00 BO-local` = **`08:00:00Z`** efectivos
+4. La comparación queda `< 08:00Z` en vez de `< 04:00Z` → **shift expansivo (+4h), incluye filas extra**
+
+**Cómo se detectó**: los tests originales (escritos según la spec) pasaron en RED sin el fix aplicado. El sub-agente del `sdd-apply` Fase 5 paró, ejecutó queries diagnósticas directas a Postgres, y reveló la dirección real del shift.
+
+### Error 2 — Cardinalidad de scenarios diferenciales (commit `7497abb`)
+
+**Lo que decía la spec original**: 3 scenarios diferenciales (A1-S7, A1-S8, A1-S9) cubren ángulos distintos del bug.
+
+**Realidad geométrica**: solo hay 2 fenómenos físicos distintos:
+- **A1-S8**: duplicación cross-page con cursor real (manifestación natural del bug en paginación)
+- **A1-S9**: verificación negativa con cursor sintetizado a un instante arbitrario + fila en rango shifted
+
+**Por qué A1-S7 colapsa**: el "rango shifted" es `[cursor, cursor+4h]`. En orden DESC, una fila en ese rango es **más reciente** que el cursor, por lo que **ya fue entregada en una página previa**. El bug se manifiesta como duplicación entre páginas (que es A1-S8), no como "fila extra en página posterior".
+
+**Cómo se detectó**: igual que el error 1 — gate TDD. El sub-agente intentó materializar A1-S7 con un setup específico, ejecutó el primer test, falló en el assertion de página 1 (orden DESC contradictorio), y reportó.
+
+### Recomendación accionable para SDD futuros
+
+**Las specs sobre bugs que dependen de comportamiento específico de un sistema externo (timezone, locale, paginación, sort order, transacciones, locks) deben incluir al menos una query/script empírico de verificación antes de listar scenarios.**
+
+No basta con razonar "Postgres debería hacer X". Verificar con `pnpm tsx -e "..."` o equivalente, capturar el output crudo, y solo entonces redactar los scenarios. El costo de la verificación empírica es ~10 minutos. El costo de re-trabajar specs + tests + commits adicionales después es ~2 horas.
+
+**Considerar agregar este chequeo al template de `sdd-spec` o como gate explícito** cuando el spec involucra alguno de estos tags: `timezone`, `pagination`, `cursor`, `transaction`, `lock`, `index`, `concurrency`.
+
+---
+
+## Aprendizaje #2 — Gate TDD funciona cuando los tests no son ornamentales
+
+### Observación
+
+El gate TDD (RED debe fallar por la razón correcta antes de aplicar el fix) se diseñó como protección contra fixes prematuros. En este SDD funcionó dos veces consecutivas como **detector de problemas en specs**, no en código:
+
+- Primera vez: detectó la dirección incorrecta del shift en la spec
+- Segunda vez: detectó la cardinalidad incorrecta de scenarios diferenciales
+
+En ambos casos, sin el gate, el fix se habría aplicado, los tests "pasarían" (porque eran no-diferenciales), y la spec quedaría con descripción incorrecta del bug. Deuda silenciosa para reviewers futuros.
+
+### Costo vs beneficio
+
+- **Costo del gate**: ~30-40 min extra por iteración (re-escribir tests, re-correr, ajustar spec)
+- **Beneficio**: spec correcta, tests diferenciales reales, fix con regresión defensiva válida
+- **Sin el gate**: deuda silenciosa difícil de detectar después (un reviewer al ver "tests pasan" no investiga si son diferenciales)
+
+### Recomendación
+
+Mantener el gate TDD como invariante en `sdd-apply`, **especialmente para fixes de bugs sutiles donde el comportamiento del sistema no es obvio** (timezone, paginación, race conditions, side effects). En esos casos, el riesgo de "test ornamental que pasa por la razón equivocada" es alto.
+
+Para refactors triviales, fixes evidentes, o features green-field, el gate puede relajarse — pero la decisión debe ser explícita y registrarse en el commit message ("TDD gate skipped because [razón]").
+
+---
+
+## Para incluir en el PR description (T-18)
+
+Versión condensada de los aprendizajes para el PR body:
+
+> ### Aprendizajes del cambio
+>
+> 1. **Specs de bugs timezone/paginación requieren verificación empírica**. Modelarlos "desde afuera" llevó a 2 errores (shift contractivo vs expansivo, cardinalidad de scenarios) que el gate TDD detectó pero costó re-trabajo. Recomendación para SDDs futuros con tags `timezone`/`pagination`/`cursor`: incluir query empírica antes de redactar scenarios.
+>
+> 2. **El gate TDD detectó problemas en specs, no en código**. En ambos casos, sin el gate, los tests "pasarían" siendo no-diferenciales y la spec quedaría con descripción incorrecta del bug. Mantener el gate como invariante para fixes de bugs sutiles.

--- a/openspec/changes/timestamptz-migration/proposal.md
+++ b/openspec/changes/timestamptz-migration/proposal.md
@@ -1,0 +1,109 @@
+# Proposal: timestamptz-migration
+
+**Fecha**: 2026-04-27
+**Cambio**: `timestamptz-migration`
+**Estado**: listo para `sdd-spec` y `sdd-design`
+
+---
+
+## Intent
+
+El sistema almacena timestamps en columnas `TIMESTAMP(3)` (sin timezone). Cuando node-postgres escribe un valor `Date` de JavaScript en una columna `TIMESTAMP`, Postgres lo interpreta como hora local de la sesión (`America/La_Paz`, UTC-4). El valor queda almacenado sin información de timezone (naive). Al leerlo, node-postgres lo recibe como naive y lo asigna a UTC directamente — produciendo una discrepancia de **4 horas hacia atrás** respecto al instante real.
+
+El impacto más visible es en el módulo de auditoría: `AuditLog.createdAt` registra cada operación contable con un timestamp 4 horas adelantado respecto a la hora real del usuario. El cursor de paginación del audit (`::timestamp` cast en `audit.repository.ts`) agrava el problema: comparar una columna TIMESTAMP con un cursor ISO-8601 produce resultados incorrectos en rangos de fecha que crucen la medianoche local, lo que significa que en producción ciertas páginas de auditoría omitirán registros o los duplicarán silenciosamente.
+
+Más allá del audit, el mismo bug afecta a 43 columnas en 20 modelos: `createdAt`, `updatedAt`, `closedAt`, `windowStart`, y otras que representan instantes reales en el tiempo. Toda observabilidad, trazabilidad, y eventual exportación de datos queda distorsionada en 4 horas. La corrección es migrar todas esas columnas a `TIMESTAMPTZ(3)` con la cláusula `USING ... AT TIME ZONE 'America/La_Paz'` para reinterpretar correctamente los datos históricos.
+
+Adicionalmente, el usuario ha decidido aprovechar este cambio para unificar el schema completo: las 17 columnas que actualmente usan el patrón UTC-noon (fechas de comprobantes escritas via `toNoonUtc()`) también migrarán a `TIMESTAMPTZ(3)`, usando `USING "col" AT TIME ZONE 'UTC'` para preservar su semántica sin alterarla. La justificación es pragmática: la base está en desarrollo sin datos productivos, y un schema uniforme elimina la ambigüedad de tener columnas `TIMESTAMP` con semánticas diferentes según el modelo.
+
+---
+
+## Scope
+
+Lo que entra en este cambio:
+
+- **Migración de schema**: las 60 columnas `DateTime` del `schema.prisma` pasan a `DateTime @db.Timestamptz(3)`. Sin exenciones.
+- **Migración SQL manual**: un único archivo de migración Prisma (generado con `--create-only` y editado a mano) con dos categorías de cláusula `USING`:
+  - `USING "col" AT TIME ZONE 'America/La_Paz'` para las ~43 columnas TIMESTAMP-AFFECTED (datos naive BO-local).
+  - `USING "col" AT TIME ZONE 'UTC'` para las ~17 columnas UTC-noon (datos ya en UTC vía `toNoonUtc()`).
+- **Fix de cursor en `audit.repository.ts`**: cambiar el cast `::timestamp` a `::timestamptz` en la cláusula WHERE de la paginación del audit. Este fix es atómico con la migración — sin él, el módulo de audit queda funcionalmente roto post-migración.
+- **Documentación en el PR**: un párrafo explícito en el cuerpo del PR indicando que se omitió `pg_dump` porque la base sólo contiene datos de ejemplo, y que esta excepción NO aplica a futuras migraciones cuando haya datos productivos.
+
+---
+
+## Approach
+
+La estrategia es una **migración única atómica con SQL editado manualmente**, siguiendo el proceso `--create-only` ya establecido en el proyecto (precedente en `cierre-periodo` y `voucher-types`).
+
+**Paso 1 — Schema Prisma**: agregar `@db.Timestamptz(3)` a cada uno de los 60 campos `DateTime` en `prisma/schema.prisma`. Esto requiere que el datasource tenga activada la extensión `postgresqlExtensions` o que el provider soporte el tipo directamente — el proyecto ya usa `postgresql` como provider, y `@db.Timestamptz` es nativo de `prisma-client-js` con Postgres.
+
+**Paso 2 — Generación del SQL base**: ejecutar `prisma migrate dev --create-only --name timestamptz_migration`. Prisma genera un archivo `.sql` con `ALTER TABLE ... ALTER COLUMN ... TYPE TIMESTAMPTZ(3)` para cada columna modificada. El SQL generado es incorrecto por defecto: Postgres aplica un casting implícito `TIMESTAMP → TIMESTAMPTZ` que asume UTC, pero los datos históricos son naive BO-local. Este es el riesgo R1 crítico identificado en el explore.
+
+**Paso 3 — Edición manual del SQL**: agregar la cláusula `USING` correcta en cada ALTER. La clasificación de qué columnas usan `AT TIME ZONE 'America/La_Paz'` versus `AT TIME ZONE 'UTC'` se establece en el design y queda documentada en la tarea de implementación. Ningún ALTER puede quedar sin su `USING` — es la restricción más importante de esta migración.
+
+**Paso 4 — Fix en `audit.repository.ts`**: cambiar el cast del cursor de `::timestamp` a `::timestamptz` en el mismo PR. Este fix es de una línea pero su ausencia sería un bug funcional silencioso en producción.
+
+**Paso 5 — Aplicación**: `prisma migrate dev` (sin `--create-only`) aplica la migración editada en una transacción. Si algún ALTER falla, toda la migración hace rollback.
+
+El approach es intencionalmente simple y conservador: una transacción, un PR, un punto de rollback. No hay pasos de backfill separados ni scripts auxiliares.
+
+### Invariante técnico crítico (debe heredarse a design y tasks)
+
+El SQL de migración requiere **dos cláusulas `USING` diferentes** aunque las 60 columnas terminen todas como `TIMESTAMPTZ(3)`:
+
+| Categoría | Columnas | Cláusula USING | Razón |
+|-----------|----------|----------------|-------|
+| TIMESTAMP-AFFECTED | ~43 (createdAt, updatedAt, closedAt, windowStart, etc.) | `USING "col" AT TIME ZONE 'America/La_Paz'` | Datos almacenados como naive BO-local; reinterpretar como instantes reales en BO-local |
+| UTC-NOON | ~17 (Sale.date, Purchase.date, dueDate, ChickenLot.startDate/endDate, Expense.date, MortalityLog.date, JournalEntry.date, FiscalPeriod.startDate/endDate, Dispatch.date, Payment.date, PurchaseDetail.fecha, IvaPurchaseBook.fechaFactura, IvaSalesBook.fechaFactura) | `USING "col" AT TIME ZONE 'UTC'` | Datos ya en UTC vía `toNoonUtc()`; preservar sin modificación |
+
+Aplicar `AT TIME ZONE 'America/La_Paz'` sobre la categoría UTC-NOON restaría 4 horas a cada valor, rompiendo el patrón UTC-noon. Esta es la corrupción de datos más probable si el SQL se aplica sin clasificar columnas. El design y las tasks deben enumerar explícitamente qué columna va en qué categoría.
+
+---
+
+## Alternatives considered
+
+| Opción | Descripción | Razón de descarte |
+|--------|-------------|-------------------|
+| **A (elegida)** | Migración única atómica con SQL editado manualmente | Correcta, atómica, alineada con el proceso del proyecto |
+| **B — Migración por batch** | Dividir en 2-3 migraciones: audit_logs primero, luego resto | Estado intermedio inconsistente: audit correcto pero otros modelos aún con bug. Peor que el estado buggy uniforme. Descartada. |
+| **C — Corrección en el cliente** | Mantener `TIMESTAMP(3)`, sumar +4h en `formatDateTimeBO` | Hack de compensación. La fuente sigue incorrecta. Queries server-side con `NOW()`, serialización ISO a APIs externas, y el cursor de audit siguen mal. Descartada definitivamente. |
+| **D — Cambiar TZ de sesión de Postgres a UTC** | `postgresql.conf` `TimeZone = UTC` o `options=-c timezone=UTC` en DATABASE_URL | No corrige datos históricos: las filas existentes tienen naive-BO-local bytes que con TZ=UTC se leerían como UTC, produciendo un bug diferente (+4h en lugar de -4h). Sin migración de datos, el problema cambia de signo pero no se resuelve. Descartada. |
+| **E — Scope parcial (sólo TIMESTAMP-AFFECTED, excluir UTC-NOON)** | Migrar sólo las 43 columnas TIMESTAMP-AFFECTED; dejar las 17 UTC-NOON como `TIMESTAMP(3)` | Técnicamente correcto dado que las UTC-NOON no presentan el bug. Descartado por decisión del usuario: base en desarrollo, sin datos productivos, se prefiere schema uniforme. Elimina ambigüedad para nuevos desarrolladores. |
+
+---
+
+## Out of scope
+
+Los siguientes cambios NO forman parte de este cambio y no deben incluirse en el mismo PR:
+
+- **Cambiar el timezone de sesión de Postgres** (`TimeZone = UTC` en `postgresql.conf` o DATABASE_URL). La sesión de Postgres puede continuar con cualquier TZ — `TIMESTAMPTZ` es inmune al timezone de sesión en lo que respecta al almacenamiento.
+- **Refactor de `toNoonUtc()`**. La función sigue siendo válida para nuevas escrituras de fechas calendario. Su eventual eliminación o reemplazo es una decisión de arquitectura de aplicación independiente de la corrección del schema.
+- **Normalización de escrituras de `dueDate`** (agregar `toNoonUtc()` en `receivables.repository.ts`). El explore identificó que `dueDate` se persiste sin `toNoonUtc()`, pero corregir eso es una tarea de normalización de datos, no de migración de tipo. Queda como deuda técnica documentada.
+- **Eliminación del patrón UTC-noon**. Post-migración, columnas como `Sale.date` seguirán almacenando valores UTC-noon — ahora como `TIMESTAMPTZ` correctos. Migrar esas columnas a un tipo `DATE` nativo de Postgres es un cambio de semántica que requiere su propio SDD.
+- **Resolución de `TZ=America/La_Paz` en el proceso server-side**. `lib/date-utils.ts` depende de la TZ del proceso para `startOfMonth`/`endOfMonth`. Esto no cambia con esta migración y es una deuda técnica separada.
+- **Tests de integración contra Postgres real**. Los tests existentes usan mocks. Agregar tests de integración que ejecuten la migración en una DB de test es un cambio de infraestructura de testing fuera del scope de esta corrección.
+- **Seed data / fixtures de timestamps**. No existe `prisma/seed.ts`. Si en el futuro se agrega, los timestamps deben ser UTC explícitos (`new Date("...Z")`).
+
+---
+
+## Operational notes
+
+### Excepción al procedimiento de backup (pg_dump)
+
+El proceso estándar del proyecto para migraciones con `USING ... AT TIME ZONE` es tomar un `pg_dump` previo (precedente en `cierre-periodo/design.md:109`). **Este cambio omite el `pg_dump` porque la base sólo contiene datos de ejemplo generados durante el desarrollo — no hay datos productivos en riesgo.**
+
+> **ADVERTENCIA para el PR**: esta excepción es específica al estado actual del proyecto (base sin datos productivos). En cualquier migración futura que modifique tipos de columna con `USING`, el `pg_dump` es OBLIGATORIO si la base tiene datos reales. Esta excepción NO establece precedente para producción.
+
+### Prerrequisitos para aplicar en producción futura
+
+Cuando la base tenga datos productivos y se necesite una migración similar, los pasos adicionales serán:
+
+1. `pg_dump -Fc -f backup_pre_migration.dump <database>` antes de cualquier ALTER.
+2. Verificar que el TZ de la sesión de Postgres en producción sea `America/La_Paz` (o ajustar los USING si difiere).
+3. Coordinar una ventana de mantenimiento: los ALTERs sobre tablas grandes (audit_logs con millones de filas) generan full-table lock por la duración del ALTER. En producción se necesitaría migraciones online (`pg_repack`, `ALTER COLUMN ... ADD CONSTRAINT ... NOT VALID`, etc.) — que están fuera del scope de este cambio.
+
+---
+
+## Open questions
+
+Ninguna. Las 5 decisiones del explore fueron respondidas por el usuario y son vinculantes para este proposal.

--- a/openspec/changes/timestamptz-migration/proposal.md
+++ b/openspec/changes/timestamptz-migration/proposal.md
@@ -12,9 +12,9 @@ El sistema almacena timestamps en columnas `TIMESTAMP(3)` (sin timezone). Cuando
 
 El impacto más visible es en el módulo de auditoría: `AuditLog.createdAt` registra cada operación contable con un timestamp 4 horas adelantado respecto a la hora real del usuario. El cursor de paginación del audit (`::timestamp` cast en `audit.repository.ts`) agrava el problema: comparar una columna TIMESTAMP con un cursor ISO-8601 produce resultados incorrectos en rangos de fecha que crucen la medianoche local, lo que significa que en producción ciertas páginas de auditoría omitirán registros o los duplicarán silenciosamente.
 
-Más allá del audit, el mismo bug afecta a 43 columnas en 20 modelos: `createdAt`, `updatedAt`, `closedAt`, `windowStart`, y otras que representan instantes reales en el tiempo. Toda observabilidad, trazabilidad, y eventual exportación de datos queda distorsionada en 4 horas. La corrección es migrar todas esas columnas a `TIMESTAMPTZ(3)` con la cláusula `USING ... AT TIME ZONE 'America/La_Paz'` para reinterpretar correctamente los datos históricos.
+Más allá del audit, el mismo bug afecta a 49 columnas en distintos modelos: `createdAt`, `updatedAt`, `closedAt`, `windowStart`, `deactivatedAt`, y otras que representan instantes reales en el tiempo. Toda observabilidad, trazabilidad, y eventual exportación de datos queda distorsionada en 4 horas. La corrección es migrar todas esas columnas a `TIMESTAMPTZ(3)` con la cláusula `USING ... AT TIME ZONE 'America/La_Paz'` para reinterpretar correctamente los datos históricos.
 
-Adicionalmente, el usuario ha decidido aprovechar este cambio para unificar el schema completo: las 17 columnas que actualmente usan el patrón UTC-noon (fechas de comprobantes escritas via `toNoonUtc()`) también migrarán a `TIMESTAMPTZ(3)`, usando `USING "col" AT TIME ZONE 'UTC'` para preservar su semántica sin alterarla. La justificación es pragmática: la base está en desarrollo sin datos productivos, y un schema uniforme elimina la ambigüedad de tener columnas `TIMESTAMP` con semánticas diferentes según el modelo.
+Adicionalmente, el usuario ha decidido aprovechar este cambio para unificar el schema completo: las 16 columnas que actualmente usan el patrón UTC-noon (fechas de comprobantes escritas via `toNoonUtc()`) también migrarán a `TIMESTAMPTZ(3)`, usando `USING "col" AT TIME ZONE 'UTC'` para preservar su semántica sin alterarla. La justificación es pragmática: la base está en desarrollo sin datos productivos, y un schema uniforme elimina la ambigüedad de tener columnas `TIMESTAMP` con semánticas diferentes según el modelo.
 
 ---
 
@@ -22,10 +22,10 @@ Adicionalmente, el usuario ha decidido aprovechar este cambio para unificar el s
 
 Lo que entra en este cambio:
 
-- **Migración de schema**: las 60 columnas `DateTime` del `schema.prisma` pasan a `DateTime @db.Timestamptz(3)`. Sin exenciones.
+- **Migración de schema**: las 65 columnas `DateTime` del `schema.prisma` pasan a `DateTime @db.Timestamptz(3)`. Sin exenciones.
 - **Migración SQL manual**: un único archivo de migración Prisma (generado con `--create-only` y editado a mano) con dos categorías de cláusula `USING`:
-  - `USING "col" AT TIME ZONE 'America/La_Paz'` para las ~43 columnas TIMESTAMP-AFFECTED (datos naive BO-local).
-  - `USING "col" AT TIME ZONE 'UTC'` para las ~17 columnas UTC-noon (datos ya en UTC vía `toNoonUtc()`).
+  - `USING "col" AT TIME ZONE 'America/La_Paz'` para las 49 columnas TIMESTAMP-AFFECTED (datos naive BO-local).
+  - `USING "col" AT TIME ZONE 'UTC'` para las 16 columnas UTC-noon (datos ya en UTC vía `toNoonUtc()`).
 - **Fix de cursor en `audit.repository.ts`**: cambiar el cast `::timestamp` a `::timestamptz` en la cláusula WHERE de la paginación del audit. Este fix es atómico con la migración — sin él, el módulo de audit queda funcionalmente roto post-migración.
 - **Documentación en el PR**: un párrafo explícito en el cuerpo del PR indicando que se omitió `pg_dump` porque la base sólo contiene datos de ejemplo, y que esta excepción NO aplica a futuras migraciones cuando haya datos productivos.
 
@@ -35,7 +35,7 @@ Lo que entra en este cambio:
 
 La estrategia es una **migración única atómica con SQL editado manualmente**, siguiendo el proceso `--create-only` ya establecido en el proyecto (precedente en `cierre-periodo` y `voucher-types`).
 
-**Paso 1 — Schema Prisma**: agregar `@db.Timestamptz(3)` a cada uno de los 60 campos `DateTime` en `prisma/schema.prisma`. Esto requiere que el datasource tenga activada la extensión `postgresqlExtensions` o que el provider soporte el tipo directamente — el proyecto ya usa `postgresql` como provider, y `@db.Timestamptz` es nativo de `prisma-client-js` con Postgres.
+**Paso 1 — Schema Prisma**: agregar `@db.Timestamptz(3)` a cada uno de los 65 campos `DateTime` en `prisma/schema.prisma`. Esto requiere que el datasource tenga activada la extensión `postgresqlExtensions` o que el provider soporte el tipo directamente — el proyecto ya usa `postgresql` como provider, y `@db.Timestamptz` es nativo de `prisma-client-js` con Postgres.
 
 **Paso 2 — Generación del SQL base**: ejecutar `prisma migrate dev --create-only --name timestamptz_migration`. Prisma genera un archivo `.sql` con `ALTER TABLE ... ALTER COLUMN ... TYPE TIMESTAMPTZ(3)` para cada columna modificada. El SQL generado es incorrecto por defecto: Postgres aplica un casting implícito `TIMESTAMP → TIMESTAMPTZ` que asume UTC, pero los datos históricos son naive BO-local. Este es el riesgo R1 crítico identificado en el explore.
 
@@ -49,12 +49,12 @@ El approach es intencionalmente simple y conservador: una transacción, un PR, u
 
 ### Invariante técnico crítico (debe heredarse a design y tasks)
 
-El SQL de migración requiere **dos cláusulas `USING` diferentes** aunque las 60 columnas terminen todas como `TIMESTAMPTZ(3)`:
+El SQL de migración requiere **dos cláusulas `USING` diferentes** aunque las 65 columnas terminen todas como `TIMESTAMPTZ(3)`:
 
 | Categoría | Columnas | Cláusula USING | Razón |
 |-----------|----------|----------------|-------|
-| TIMESTAMP-AFFECTED | ~43 (createdAt, updatedAt, closedAt, windowStart, etc.) | `USING "col" AT TIME ZONE 'America/La_Paz'` | Datos almacenados como naive BO-local; reinterpretar como instantes reales en BO-local |
-| UTC-NOON | ~17 (Sale.date, Purchase.date, dueDate, ChickenLot.startDate/endDate, Expense.date, MortalityLog.date, JournalEntry.date, FiscalPeriod.startDate/endDate, Dispatch.date, Payment.date, PurchaseDetail.fecha, IvaPurchaseBook.fechaFactura, IvaSalesBook.fechaFactura) | `USING "col" AT TIME ZONE 'UTC'` | Datos ya en UTC vía `toNoonUtc()`; preservar sin modificación |
+| TIMESTAMP-AFFECTED | 49 (createdAt, updatedAt, closedAt, windowStart, deactivatedAt) | `USING "col" AT TIME ZONE 'America/La_Paz'` | Datos almacenados como naive BO-local; reinterpretar como instantes reales en BO-local |
+| UTC-NOON | 16 (Sale.date, Purchase.date, Dispatch.date, Payment.date, JournalEntry.date, FiscalPeriod.startDate/endDate, ChickenLot.startDate/endDate, Expense.date, MortalityLog.date, PurchaseDetail.fecha, IvaPurchaseBook.fechaFactura, IvaSalesBook.fechaFactura, AccountsReceivable.dueDate, AccountsPayable.dueDate) | `USING "col" AT TIME ZONE 'UTC'` | Datos ya en UTC vía `toNoonUtc()`; preservar sin modificación |
 
 Aplicar `AT TIME ZONE 'America/La_Paz'` sobre la categoría UTC-NOON restaría 4 horas a cada valor, rompiendo el patrón UTC-noon. Esta es la corrupción de datos más probable si el SQL se aplica sin clasificar columnas. El design y las tasks deben enumerar explícitamente qué columna va en qué categoría.
 
@@ -68,7 +68,7 @@ Aplicar `AT TIME ZONE 'America/La_Paz'` sobre la categoría UTC-NOON restaría 4
 | **B — Migración por batch** | Dividir en 2-3 migraciones: audit_logs primero, luego resto | Estado intermedio inconsistente: audit correcto pero otros modelos aún con bug. Peor que el estado buggy uniforme. Descartada. |
 | **C — Corrección en el cliente** | Mantener `TIMESTAMP(3)`, sumar +4h en `formatDateTimeBO` | Hack de compensación. La fuente sigue incorrecta. Queries server-side con `NOW()`, serialización ISO a APIs externas, y el cursor de audit siguen mal. Descartada definitivamente. |
 | **D — Cambiar TZ de sesión de Postgres a UTC** | `postgresql.conf` `TimeZone = UTC` o `options=-c timezone=UTC` en DATABASE_URL | No corrige datos históricos: las filas existentes tienen naive-BO-local bytes que con TZ=UTC se leerían como UTC, produciendo un bug diferente (+4h en lugar de -4h). Sin migración de datos, el problema cambia de signo pero no se resuelve. Descartada. |
-| **E — Scope parcial (sólo TIMESTAMP-AFFECTED, excluir UTC-NOON)** | Migrar sólo las 43 columnas TIMESTAMP-AFFECTED; dejar las 17 UTC-NOON como `TIMESTAMP(3)` | Técnicamente correcto dado que las UTC-NOON no presentan el bug. Descartado por decisión del usuario: base en desarrollo, sin datos productivos, se prefiere schema uniforme. Elimina ambigüedad para nuevos desarrolladores. |
+| **E — Scope parcial (sólo TIMESTAMP-AFFECTED, excluir UTC-NOON)** | Migrar sólo las 49 columnas TIMESTAMP-AFFECTED; dejar las 16 UTC-NOON como `TIMESTAMP(3)` | Técnicamente correcto dado que las UTC-NOON no presentan el bug. Descartado por decisión del usuario: base en desarrollo, sin datos productivos, se prefiere schema uniforme. Elimina ambigüedad para nuevos desarrolladores. |
 
 ---
 

--- a/openspec/changes/timestamptz-migration/specs/audit-module/spec.md
+++ b/openspec/changes/timestamptz-migration/specs/audit-module/spec.md
@@ -1,0 +1,77 @@
+# Delta: audit-module
+
+**Change**: `timestamptz-migration`
+**Capacity**: `audit-module`
+**Decision**: MODIFIED — La capacidad ya existe en `openspec/specs/audit-module/spec.md` (archivada del cambio `2026-04-24-modulo-de-auditoria`). Este delta modifica `REQ-AUDIT.1` para que el comportamiento de paginación cursor-based sea correcto con columnas `TIMESTAMPTZ(3)`. El fix del cast `::timestamp` → `::timestamptz` en `audit.repository.ts` es el mecanismo de implementación; el REQ modificado describe el contrato observable.
+
+---
+
+## Contexto del cambio
+
+El cursor de paginación en `audit.repository.ts` serializa el cursor como `last.createdAt.toISOString()` (un string ISO-8601 con sufijo Z, representando UTC). La cláusula WHERE compara:
+
+```sql
+awp."createdAt" < ${cursorCreatedAt}::timestamp
+```
+
+Con la columna `createdAt` como `TIMESTAMP(3)` (sin timezone), el cast `::timestamp` era compatible porque ambos lados eran naive. Post-migración a `TIMESTAMPTZ(3)`, el cast `::timestamp` descarta la información de timezone del string ISO-8601 antes de la comparación, produciendo comparaciones incorrectas en rangos que crucen la medianoche local (`America/La_Paz`). El fix es cambiar el cast a `::timestamptz`.
+
+---
+
+## Requirements MODIFIED
+
+### REQ-AUDIT.1 — Read endpoint: lista paginada por rango de fechas *(modificado)*
+
+> **Base**: ver `openspec/specs/audit-module/spec.md` REQ-AUDIT.1 para el contrato completo (endpoint, filtros, page size 50, defaults de fecha).
+
+**Modificación**: el cursor de paginación DEBE comparar la columna `audit_logs.createdAt` (`TIMESTAMPTZ(3)` post-migración) usando un cast `::timestamptz` (no `::timestamp`). La comparación DEBE preservar la información de timezone del cursor serializado para garantizar orden estable en cualquier rango de fechas, incluyendo rangos que crucen la medianoche local.
+
+#### Scenarios añadidos
+
+##### A1-S7 — cursor serializado en UTC se compara correctamente con columna TIMESTAMPTZ
+- **Given** la columna `audit_logs.createdAt` es `TIMESTAMPTZ(3)`
+- **AND** el cursor se serializa como `last.createdAt.toISOString()` (ej. `"2026-04-27T04:00:00.000Z"` — que corresponde a la medianoche de `2026-04-27` en `America/La_Paz`)
+- **When** el endpoint recibe ese cursor y construye la cláusula WHERE
+- **Then** la comparación se realiza como `awp."createdAt" < '2026-04-27T04:00:00.000Z'::timestamptz`
+- **AND** el resultado incluye exactamente las filas con `createdAt < 2026-04-27T04:00:00Z` (UTC) sin omisiones ni duplicados
+
+##### A1-S8 — paginación cross-medianoche mantiene orden estable con TIMESTAMPTZ
+- **Given** existen filas de audit_logs con `createdAt` en el rango `2026-04-26T23:50:00Z` a `2026-04-27T00:10:00Z` (UTC), que en `America/La_Paz` corresponden al rango `19:50:00` del 26 al `20:10:00` del 26 — es decir, cruzan la medianoche UTC pero NO la medianoche local
+- **When** se pagina sobre ese rango con cursor-based pagination usando `::timestamptz`
+- **Then** todas las filas aparecen exactamente una vez, en orden `createdAt DESC`, sin duplicados ni omisiones entre páginas consecutivas
+
+##### A1-S9 — cast `::timestamp` produce resultado incorrecto (verificación negativa)
+- **Given** la columna `audit_logs.createdAt` es `TIMESTAMPTZ(3)` y existe una fila con `createdAt = '2026-04-27T04:00:00.000+00'`
+- **When** se compara usando `::timestamp` en lugar de `::timestamptz` (comportamiento incorrecto — este scenario documenta el bug que se corrige)
+- **Then** Postgres convierte el string ISO al timezone de sesión antes de comparar, produciendo un offset de -4h que hace que la comparación evalúe contra `2026-04-27T00:00:00` local en lugar del instante UTC correcto — resultado: filas pueden duplicarse o perderse entre páginas
+
+> **Nota**: el Scenario A1-S9 documenta el comportamiento incorrecto para referencia y para que el test de regresión pueda verificar que el bug NO reproduce con el fix aplicado.
+
+---
+
+## Requirements NO modificados
+
+Los siguientes REQs de `audit-module` quedan sin cambios en este delta:
+
+| REQ | Estado | Justificación |
+|-----|--------|---------------|
+| REQ-AUDIT.2 | Sin cambio | El detail endpoint ordena por `createdAt ASC` sin cursor — no se ve afectado por el tipo de columna |
+| REQ-AUDIT.3 | Sin cambio | El classifier directa/indirecta no depende del tipo de columna |
+| REQ-AUDIT.4 | Sin cambio | Tenant isolation no depende del tipo de columna |
+| REQ-AUDIT.5 | Sin cambio | Invariante `$queryRaw` con `organizationId` como primer bound no depende del tipo |
+| REQ-AUDIT.6 | Sin cambio | Permisos no dependen del tipo de columna |
+| REQ-AUDIT.7 | Sin cambio | Data migration de permiso "audit" no depende del tipo de columna |
+| REQ-AUDIT.8 | Sin cambio | Los índices `[organizationId, entityType, createdAt]` y `[organizationId, changedById, createdAt]` funcionan correctamente con `TIMESTAMPTZ` — btree es agnóstico al tipo de timezone |
+| REQ-AUDIT.9 | Sin cambio | UI diff viewer no depende del tipo de columna |
+| REQ-AUDIT.10 | Sin cambio | Feature module boundaries no dependen del tipo de columna |
+
+---
+
+## Traceability — Proposal → REQs MODIFIED
+
+| Sección del proposal | REQ modificado |
+|---------------------|----------------|
+| Intent — cursor `::timestamp` produce paginación incorrecta post-migración | REQ-AUDIT.1 (A1-S7, A1-S8, A1-S9) |
+| Scope — fix de cursor en `audit.repository.ts` es atómico con la migración | REQ-AUDIT.1 (modificación) |
+| R3 (exploration) — cursor pagination del audit usa `::timestamp` cast | REQ-AUDIT.1 (A1-S9) |
+| Decisión 5 (decisions engram) — fix `::timestamp` → `::timestamptz` en mismo PR | REQ-AUDIT.1 |

--- a/openspec/changes/timestamptz-migration/specs/audit-module/spec.md
+++ b/openspec/changes/timestamptz-migration/specs/audit-module/spec.md
@@ -14,7 +14,16 @@ El cursor de paginación en `audit.repository.ts` serializa el cursor como `last
 awp."createdAt" < ${cursorCreatedAt}::timestamp
 ```
 
-Con la columna `createdAt` como `TIMESTAMP(3)` (sin timezone), el cast `::timestamp` era compatible porque ambos lados eran naive. Post-migración a `TIMESTAMPTZ(3)`, el cast `::timestamp` descarta la información de timezone del string ISO-8601 antes de la comparación, produciendo comparaciones incorrectas en rangos que crucen la medianoche local (`America/La_Paz`). El fix es cambiar el cast a `::timestamptz`.
+Con la columna `createdAt` como `TIMESTAMP(3)` (sin timezone), el cast `::timestamp` era compatible porque ambos lados eran naive. Post-migración a `TIMESTAMPTZ(3)`, el comportamiento real (verificado empíricamente contra Postgres) es:
+
+1. El cast `::timestamp` descarta el sufijo `Z` del string ISO. El cursor `'2026-04-27T04:00:00.000Z'::timestamp` produce el TIMESTAMP naive `2026-04-27T04:00:00.000` (sin TZ).
+2. Postgres compara `timestamptz_col < timestamp_value` coerce-ando el TIMESTAMP a TIMESTAMPTZ usando `current_setting('TimeZone')` (la sesión de Postgres corre en `America/La_Paz`).
+3. El cursor `04:00:00` naive se interpreta como `04:00 BO-local` = **`08:00:00Z`** efectivos para la comparación.
+4. La comparación queda `awp."createdAt" < '2026-04-27T08:00:00Z'` en lugar de `< '2026-04-27T04:00:00Z'`.
+
+**Failure mode**: el shift de +4h **expande el rango** efectivo de la comparación. Filas con `createdAt` entre `04:00Z` y `08:00Z` (que NO deberían estar antes del cursor) son incluidas incorrectamente. En una paginación cursor-based, esto produce **filas duplicadas** entre páginas adyacentes (una fila en el rango shifted aparece tanto en la página de "antes del cursor" como en la página que la generó como cursor).
+
+El fix es cambiar el cast a `::timestamptz`, que preserva el sufijo `Z` del string ISO y produce comparación UTC-to-UTC sin depender de `session_timezone`.
 
 ---
 
@@ -28,24 +37,32 @@ Con la columna `createdAt` como `TIMESTAMP(3)` (sin timezone), el cast `::timest
 
 #### Scenarios añadidos
 
-##### A1-S7 — cursor serializado en UTC se compara correctamente con columna TIMESTAMPTZ
+##### A1-S7 — cursor serializado en UTC se compara correctamente con columna TIMESTAMPTZ (sin shift expansivo)
 - **Given** la columna `audit_logs.createdAt` es `TIMESTAMPTZ(3)`
 - **AND** el cursor se serializa como `last.createdAt.toISOString()` (ej. `"2026-04-27T04:00:00.000Z"` — que corresponde a la medianoche de `2026-04-27` en `America/La_Paz`)
-- **When** el endpoint recibe ese cursor y construye la cláusula WHERE
-- **Then** la comparación se realiza como `awp."createdAt" < '2026-04-27T04:00:00.000Z'::timestamptz`
-- **AND** el resultado incluye exactamente las filas con `createdAt < 2026-04-27T04:00:00Z` (UTC) sin omisiones ni duplicados
+- **AND** existen filas con `createdAt` entre `2026-04-27T04:00:00Z` y `2026-04-27T08:00:00Z` (el "rango shifted" — el rango que el bug `::timestamp` incluiría incorrectamente)
+- **When** el endpoint recibe ese cursor y construye la cláusula WHERE con `::timestamptz`
+- **Then** la comparación se realiza como `awp."createdAt" < '2026-04-27T04:00:00.000Z'::timestamptz` (UTC-to-UTC, sin coerción por session_timezone)
+- **AND** el resultado **NO contiene** las filas del rango shifted (porque sus `createdAt` no son `< 04:00Z`)
+- **AND** el resultado incluye exactamente las filas con `createdAt < 2026-04-27T04:00:00Z` (UTC), sin filas extra del rango shifted
 
-##### A1-S8 — paginación cross-medianoche mantiene orden estable con TIMESTAMPTZ
-- **Given** existen filas de audit_logs con `createdAt` en el rango `2026-04-26T23:50:00Z` a `2026-04-27T00:10:00Z` (UTC), que en `America/La_Paz` corresponden al rango `19:50:00` del 26 al `20:10:00` del 26 — es decir, cruzan la medianoche UTC pero NO la medianoche local
+##### A1-S8 — paginación cross-medianoche sin duplicados (con `::timestamptz`)
+- **Given** existen filas de audit_logs con `createdAt` que cruzan la medianoche UTC, incluyendo al menos una fila en el "rango shifted" (entre el instante del cursor y `cursor + 4h`)
 - **When** se pagina sobre ese rango con cursor-based pagination usando `::timestamptz`
-- **Then** todas las filas aparecen exactamente una vez, en orden `createdAt DESC`, sin duplicados ni omisiones entre páginas consecutivas
+- **Then** todas las filas aparecen exactamente una vez en orden `createdAt DESC`
+- **AND** las filas del rango shifted aparecen sólo en su página correcta (la de "después del cursor"), NO duplicadas en la página anterior (esto es lo que el bug `::timestamp` haría: incluirlas en ambas páginas porque el cursor efectivo se desplaza +4h)
 
-##### A1-S9 — cast `::timestamp` produce resultado incorrecto (verificación negativa)
-- **Given** la columna `audit_logs.createdAt` es `TIMESTAMPTZ(3)` y existe una fila con `createdAt = '2026-04-27T04:00:00.000+00'`
-- **When** se compara usando `::timestamp` en lugar de `::timestamptz` (comportamiento incorrecto — este scenario documenta el bug que se corrige)
-- **Then** Postgres convierte el string ISO al timezone de sesión antes de comparar, produciendo un offset de -4h que hace que la comparación evalúe contra `2026-04-27T00:00:00` local en lugar del instante UTC correcto — resultado: filas pueden duplicarse o perderse entre páginas
+##### A1-S9 — cast `::timestamp` produce shift expansivo de +4h (verificación negativa, comportamiento que el fix elimina)
+- **Given** la columna `audit_logs.createdAt` es `TIMESTAMPTZ(3)`
+- **AND** la sesión de Postgres corre con `TimeZone = 'America/La_Paz'` (UTC-4)
+- **AND** existe una fila con `createdAt = '2026-04-27T06:00:00.000Z'` (en el "rango shifted" entre `04:00Z` y `08:00Z`)
+- **When** se compara usando `::timestamp` (comportamiento incorrecto — este scenario documenta el bug que el fix corrige) con cursor `'2026-04-27T04:00:00.000Z'`
+- **Then** Postgres descarta el sufijo `Z` del string ISO y obtiene el TIMESTAMP naive `2026-04-27T04:00:00.000`
+- **AND** al comparar `timestamptz_col < timestamp_value`, Postgres coerce el TIMESTAMP a TIMESTAMPTZ usando `session_timezone = 'America/La_Paz'`, transformando el cursor en `'2026-04-27T08:00:00.000Z'` efectivo
+- **AND** la fila `06:00Z` (que NO debería estar antes del cursor `04:00Z`) **es incluida incorrectamente** en el resultado porque `06:00Z < 08:00Z` evalúa true
+- **AND** en una paginación multi-página, esa misma fila puede aparecer **duplicada** en páginas adyacentes (en la página actual via el cursor shifted, y en una página posterior via su cursor real)
 
-> **Nota**: el Scenario A1-S9 documenta el comportamiento incorrecto para referencia y para que el test de regresión pueda verificar que el bug NO reproduce con el fix aplicado.
+> **Nota**: el Scenario A1-S9 documenta el bug observado empíricamente — el shift es **expansivo** (incluye filas extra) y produce **duplicados**, no omisiones. El fix `::timestamptz` preserva el sufijo `Z` y elimina la coerción por session_timezone, garantizando comparación UTC-to-UTC. El test de regresión correspondiente debe sembrar al menos una fila en el rango shifted y verificar `.not.toContain()` de esa fila en la página de "antes del cursor".
 
 ---
 

--- a/openspec/changes/timestamptz-migration/specs/audit-module/spec.md
+++ b/openspec/changes/timestamptz-migration/specs/audit-module/spec.md
@@ -37,14 +37,11 @@ El fix es cambiar el cast a `::timestamptz`, que preserva el sufijo `Z` del stri
 
 #### Scenarios añadidos
 
-##### A1-S7 — cursor serializado en UTC se compara correctamente con columna TIMESTAMPTZ (sin shift expansivo)
-- **Given** la columna `audit_logs.createdAt` es `TIMESTAMPTZ(3)`
-- **AND** el cursor se serializa como `last.createdAt.toISOString()` (ej. `"2026-04-27T04:00:00.000Z"` — que corresponde a la medianoche de `2026-04-27` en `America/La_Paz`)
-- **AND** existen filas con `createdAt` entre `2026-04-27T04:00:00Z` y `2026-04-27T08:00:00Z` (el "rango shifted" — el rango que el bug `::timestamp` incluiría incorrectamente)
-- **When** el endpoint recibe ese cursor y construye la cláusula WHERE con `::timestamptz`
-- **Then** la comparación se realiza como `awp."createdAt" < '2026-04-27T04:00:00.000Z'::timestamptz` (UTC-to-UTC, sin coerción por session_timezone)
-- **AND** el resultado **NO contiene** las filas del rango shifted (porque sus `createdAt` no son `< 04:00Z`)
-- **AND** el resultado incluye exactamente las filas con `createdAt < 2026-04-27T04:00:00Z` (UTC), sin filas extra del rango shifted
+##### A1-S7 — descripción del invariante (consolidado en A1-S8 a nivel de test)
+> **CONSOLIDADO**: este scenario describe el invariante general "cursor ISO-Z se compara UTC-to-UTC sin shift expansivo", pero **no genera un test diferencial independiente**. Al intentar materializarlo como test (sembrar una fila en el "rango shifted" `[cursor, cursor+4h]`), colapsa geométricamente con A1-S8: una fila más reciente que el cursor en orden DESC ya fue entregada en una página previa, por lo que el bug se manifiesta como **duplicación cross-page**, no como "filas extra en la página posterior". El fenómeno físico es el mismo desde el punto de vista del WHERE clause, pero el ángulo testeable diferencial es el de A1-S8. Se preserva A1-S7 aquí solo como descripción del invariante para reviewers que busquen el principio antes que el assertion concreto.
+
+- **Invariante**: la comparación del cursor con `audit_logs.createdAt` (TIMESTAMPTZ post-migración) DEBE preservar el sufijo `Z` del string ISO y producir comparación UTC-to-UTC, sin coerción del cursor a `session_timezone`. El fix `::timestamptz` lo garantiza.
+- **Test diferencial correspondiente**: ver A1-S8 (manifestación cross-page del fenómeno) y A1-S9 (verificación negativa con cursor sintetizado).
 
 ##### A1-S8 — paginación cross-medianoche sin duplicados (con `::timestamptz`)
 - **Given** existen filas de audit_logs con `createdAt` que cruzan la medianoche UTC, incluyendo al menos una fila en el "rango shifted" (entre el instante del cursor y `cursor + 4h`)
@@ -62,7 +59,9 @@ El fix es cambiar el cast a `::timestamptz`, que preserva el sufijo `Z` del stri
 - **AND** la fila `06:00Z` (que NO debería estar antes del cursor `04:00Z`) **es incluida incorrectamente** en el resultado porque `06:00Z < 08:00Z` evalúa true
 - **AND** en una paginación multi-página, esa misma fila puede aparecer **duplicada** en páginas adyacentes (en la página actual via el cursor shifted, y en una página posterior via su cursor real)
 
-> **Nota**: el Scenario A1-S9 documenta el bug observado empíricamente — el shift es **expansivo** (incluye filas extra) y produce **duplicados**, no omisiones. El fix `::timestamptz` preserva el sufijo `Z` y elimina la coerción por session_timezone, garantizando comparación UTC-to-UTC. El test de regresión correspondiente debe sembrar al menos una fila en el rango shifted y verificar `.not.toContain()` de esa fila en la página de "antes del cursor".
+> **Nota**: los Scenarios A1-S8 y A1-S9 documentan el bug observado empíricamente — el shift es **expansivo** (incluye filas extra) y produce **duplicados**, no omisiones. El fix `::timestamptz` preserva el sufijo `Z` y elimina la coerción por session_timezone, garantizando comparación UTC-to-UTC.
+>
+> **Tests diferenciales (2, no 3)**: solo A1-S8 y A1-S9 generan tests diferenciales independientes. A1-S7 quedó consolidado en A1-S8 (ver nota en A1-S7 arriba). Los tests deben sembrar al menos una fila en el rango shifted `[cursor, cursor+4h]` y verificar `.not.toContain()` (A1-S9) o ausencia de duplicación cross-page (A1-S8).
 
 ---
 

--- a/openspec/changes/timestamptz-migration/specs/audit-module/spec.md
+++ b/openspec/changes/timestamptz-migration/specs/audit-module/spec.md
@@ -62,6 +62,8 @@ El fix es cambiar el cast a `::timestamptz`, que preserva el sufijo `Z` del stri
 > **Nota**: los Scenarios A1-S8 y A1-S9 documentan el bug observado empíricamente — el shift es **expansivo** (incluye filas extra) y produce **duplicados**, no omisiones. El fix `::timestamptz` preserva el sufijo `Z` y elimina la coerción por session_timezone, garantizando comparación UTC-to-UTC.
 >
 > **Tests diferenciales (2, no 3)**: solo A1-S8 y A1-S9 generan tests diferenciales independientes. A1-S7 quedó consolidado en A1-S8 (ver nota en A1-S7 arriba). Los tests deben sembrar al menos una fila en el rango shifted `[cursor, cursor+4h]` y verificar `.not.toContain()` (A1-S9) o ausencia de duplicación cross-page (A1-S8).
+>
+> **Estado de implementación de los tests A1-S8 y A1-S9**: NO IMPLEMENTADOS en este SDD. Razón técnica: el cambio incluye fix del adapter Prisma (`options: '-c timezone=UTC'` en commit `6fe4eef`) que fuerza `session_timezone='UTC'` en cada conexión del pool. Bajo session UTC, los casts `::timestamp` y `::timestamptz` producen resultados idénticos en comparaciones contra TIMESTAMPTZ — los tests serían no-diferenciales (pasarían tanto con `::timestamp` como con `::timestamptz`). Reproducir el bug requeriría infraestructura de test que permita cambiar `session_timezone` (ej. `SET LOCAL timezone='America/La_Paz'` dentro de transacción de test) — complejidad desproporcionada para un fix de 3 líneas ya protegido por la config del adapter. Si en el futuro se observa regresión en cursor pagination del audit, este scenario sirve como guía para escribir el test diferencial bajo el contexto adecuado (session no-UTC).
 
 ---
 

--- a/openspec/changes/timestamptz-migration/specs/persistence-timezone/spec.md
+++ b/openspec/changes/timestamptz-migration/specs/persistence-timezone/spec.md
@@ -152,11 +152,50 @@ Los triggers PostgreSQL existentes que usan `NOW()` para poblar `audit_logs.crea
 
 ---
 
+### REQ-TZ.6 — `session_timezone` forzado a `UTC` en el adapter Prisma
+
+El adapter `@prisma/adapter-pg` DEBE configurarse para que cada conexión del pool inicialice `session_timezone='UTC'`. Esta invariante es **crítica para la correctness de las escrituras y lecturas de TIMESTAMPTZ desde código JS**: el adapter `@prisma/adapter-pg@7.7.0` y versiones similares descartan información de zona horaria en ambas direcciones del wire (escritura: `formatDateTime` envía string naive sin sufijo `Z` ni `+00`; lectura: `normalize_timestamptz` reemplaza el offset real por `+00:00` mediante regex). Con `session_timezone` distinto de `UTC`, esos comportamientos producen un shift sistemático del instante real igual al offset de la zona de sesión.
+
+Esta invariante NO es decorativa — su ausencia reintroduce los bugs originales del SDD aunque las columnas sean `TIMESTAMPTZ` y el adapter no haya cambiado.
+
+#### Scenarios
+
+##### S1 — `lib/prisma.ts` configura el adapter con `options: '-c timezone=UTC'`
+- **Given** el archivo `lib/prisma.ts` instancia `new PrismaPg({ ... })`
+- **When** se inspecciona el constructor del adapter
+- **Then** las opciones del pool incluyen `options: '-c timezone=UTC'` (o equivalente como `?options=-c%20timezone=UTC` en `DATABASE_URL`) para forzar `session_timezone='UTC'` en cada conexión inicializada
+
+##### S2 — `SHOW TimeZone` retorna `UTC` en cualquier conexión Prisma
+- **Given** una operación cualquiera contra la DB vía Prisma (`prisma.$queryRaw`, `prisma.X.findMany`, etc.)
+- **When** se ejecuta `SHOW TimeZone` en la misma sesión
+- **Then** el resultado es `UTC`
+
+##### S3 — Nuevas escrituras desde código JS preservan el instante UTC real
+- **Given** la config del adapter con `options: '-c timezone=UTC'` aplicada
+- **When** se ejecuta `prisma.X.create({ data: { dateField: new Date("2026-04-27T06:00:00.000Z") } })` con cualquier modelo que tenga columna TIMESTAMPTZ
+- **Then** la columna almacena `2026-04-27 06:00:00.000+00` (UTC real, sin shift de +4h)
+- **AND** el comportamiento se aplica también a `@updatedAt` (que internamente usa `new Date()` en JS) — los UPDATE preservan el instante real
+
+##### S4 — Lecturas desde código JS reconstruyen el instante UTC real
+- **Given** la columna almacena `2026-04-27 06:00:00.000+00` (UTC real)
+- **When** Prisma la lee y la entrega como `Date` JS
+- **Then** `date.toISOString()` retorna `"2026-04-27T06:00:00.000Z"` (sin shift de -4h del adapter `normalize_timestamptz`)
+- **AND** `formatDateTimeBO(date)` muestra la hora correcta en `America/La_Paz` (= `02:00` el 27/04)
+
+##### S5 — Reversión del adapter config reintroduce los bugs (verificación negativa, NO testear)
+- **Given** la config del adapter SIN `options: '-c timezone=UTC'` y `session_timezone` de la DB en cualquier valor distinto de UTC (ej. `'America/La_Paz'`)
+- **When** se ejecuta `prisma.X.create({ data: { dateField: new Date("...Z") } })`
+- **Then** el dato almacenado sufre un shift sistemático igual al offset de la zona de sesión (ej. +4h con La_Paz)
+- **AND** las lecturas posteriores producen Date 4h antes del instante real
+- **Nota**: este scenario documenta la condición de regresión. NO debe convertirse en un test automatizado — la fix es la invariante S1, no un test que reproduzca el bug
+
+---
+
 ## Out of Scope (no speccable en este cambio)
 
 | Item | Justificación |
 |------|---------------|
-| Cambio del TZ de sesión de Postgres | No es necesario: `TIMESTAMPTZ` es inmune al timezone de sesión para el almacenamiento |
+| Cambio del TZ a nivel de DB con `ALTER DATABASE ... SET timezone` | No se aplica a nivel de servidor; el cambio se hace a nivel de adapter Prisma vía `options: '-c timezone=UTC'` (REQ-TZ.6). Esto contiene el alcance al pool de conexiones de la app sin afectar otros consumidores (CLI psql, scripts externos, futuros servicios) |
 | Refactor de `toNoonUtc()` | La función sigue siendo válida para nuevas escrituras de fechas calendario |
 | Normalización de `dueDate` en `receivables.repository.ts` (agregar `toNoonUtc()`) | Deuda técnica separada; no es parte de la migración de tipo |
 | Eliminación del patrón UTC-noon | Cambio de semántica que requiere su propio SDD |

--- a/openspec/changes/timestamptz-migration/specs/persistence-timezone/spec.md
+++ b/openspec/changes/timestamptz-migration/specs/persistence-timezone/spec.md
@@ -1,0 +1,180 @@
+# Delta: persistence-timezone
+
+**Change**: `timestamptz-migration`
+**Capacity**: `persistence-timezone`
+**Decision**: ADDED — La capacidad no existía previamente en `openspec/specs/`. Este cambio la introduce como modelación formal: todos los campos `DateTime` de Prisma que representan instantes en el tiempo DEBEN almacenarse como `TIMESTAMPTZ(3)` en PostgreSQL. La capacidad cubre el contrato de almacenamiento de instantes, la preservación semántica de datos históricos durante la migración, y la categorización explícita del SQL que distingue dos orígenes de datos distintos.
+
+---
+
+## Contexto
+
+El sistema almacenaba todos los campos `DateTime` de Prisma como `TIMESTAMP(3)` (sin timezone). node-postgres escribe un `Date` de JavaScript en una columna `TIMESTAMP` usando el timezone de sesión de Postgres (`America/La_Paz`, UTC-4): el valor queda almacenado como naive-local. Al leerlo, node-postgres lo asigna a UTC directamente, produciendo una discrepancia de **4 horas hacia atrás** respecto al instante real.
+
+La migración lleva las 65 columnas `DateTime` del schema a `TIMESTAMPTZ(3)`. El SQL de migración requiere dos cláusulas `USING` distintas según la semántica del dato almacenado:
+
+| Categoría | Columnas | Cláusula USING |
+|-----------|----------|----------------|
+| **TIMESTAMP-AFFECTED** | 48 columnas (todos los `createdAt`, `updatedAt`, `closedAt`, `windowStart`, `deactivatedAt`) | `USING "col" AT TIME ZONE 'America/La_Paz'` |
+| **UTC-NOON** | 17 columnas (`Sale.date`, `Purchase.date`, `Dispatch.date`, `Payment.date`, `JournalEntry.date`, `FiscalPeriod.startDate/endDate`, `ChickenLot.startDate/endDate`, `Expense.date`, `MortalityLog.date`, `PurchaseDetail.fecha`, `IvaPurchaseBook.fechaFactura`, `IvaSalesBook.fechaFactura`, `AccountsReceivable.dueDate`, `AccountsPayable.dueDate`) | `USING "col" AT TIME ZONE 'UTC'` |
+
+> **Nota**: la lista exhaustiva de las 65 columnas con su categoría está en `design.md` (Inventario columna-por-columna — Tabla canónica). Esa tabla es la fuente canónica para la generación del SQL.
+
+> **Nota sobre la categoría UTC-NOON**: el scope final decidido por el usuario migra las 65 columnas sin exenciones. Las columnas que en la exploración se catalogaron como DATE-CALENDAR-NOON/AMBIGUA se migran igualmente a TIMESTAMPTZ, usando `USING "col" AT TIME ZONE 'UTC'` para preservar su semántica UTC-noon sin alterarla.
+
+---
+
+## Requirements
+
+### REQ-TZ.1 — Todas las columnas DateTime del schema se almacenan como TIMESTAMPTZ(3)
+
+Todas las columnas declaradas como `DateTime` (o `DateTime?`) en `prisma/schema.prisma` DEBEN mapearse a `TIMESTAMPTZ(3)` en PostgreSQL. Ninguna columna `DateTime` del schema puede quedar como `TIMESTAMP(3)` (sin timezone) post-migración.
+
+#### Scenarios
+
+##### S1 — `createdAt` de cualquier modelo se persiste como instante UTC absoluto
+- **Given** un modelo con columna `createdAt @default(now())`
+- **When** se inserta una nueva fila
+- **Then** la columna se almacena como `TIMESTAMPTZ(3)` y representa el instante UTC real del momento de inserción, sin ambigüedad de zona horaria
+
+##### S2 — `updatedAt` refleja el instante UTC real de la última modificación
+- **Given** un modelo con columna `updatedAt @updatedAt`
+- **When** se actualiza cualquier campo de la fila
+- **Then** `updatedAt` se actualiza a un valor `TIMESTAMPTZ(3)` que representa el instante UTC real de la modificación
+
+##### S3 — Re-render correcto en timezone del cliente
+- **Given** una fila almacenada con `createdAt` como `TIMESTAMPTZ(3)` representando un instante UTC real
+- **When** se lee desde el cliente y se formatea con `formatDateTimeBO` (que usa `Intl.DateTimeFormat` con `timeZone: "America/La_Paz"`)
+- **Then** la hora mostrada coincide con la hora real del evento en `America/La_Paz` (UTC-4), sin discrepancia de 4 horas
+
+##### S4 — Inspección directa de la columna en PostgreSQL muestra TIMESTAMPTZ
+- **Given** la migración `timestamptz_migration` ha sido aplicada
+- **When** se ejecuta `\d <table_name>` en psql para cualquier tabla que contenía columnas `DateTime`
+- **Then** cada columna `DateTime` aparece con tipo `timestamp(3) with time zone` (equivalente a `TIMESTAMPTZ(3)`) y ninguna aparece como `timestamp without time zone`
+
+##### S5 — node-postgres lee TIMESTAMPTZ correctamente como UTC
+- **Given** una fila cuya columna `createdAt` fue almacenada con el instante `2026-04-27T16:30:00Z` (UTC)
+- **When** Prisma/node-postgres la lee y la devuelve como `Date` de JavaScript
+- **Then** `createdAt.toISOString()` retorna `"2026-04-27T16:30:00.000Z"` (el instante UTC real, sin shift de 4 horas)
+
+---
+
+### REQ-TZ.2 — La migración SQL preserva la semántica de los datos históricos
+
+El archivo SQL de migración DEBE usar la cláusula `USING ... AT TIME ZONE` correcta para cada columna según su categoría de origen. Ningún `ALTER TABLE ... ALTER COLUMN ... TYPE TIMESTAMPTZ(3)` puede quedar sin su cláusula `USING`.
+
+La distinción es invariante: aplicar `AT TIME ZONE 'America/La_Paz'` sobre datos UTC-noon les restaría 4 horas y corrompería los valores; aplicar `AT TIME ZONE 'UTC'` sobre datos naive BO-local los trataría como UTC y también los corrompería.
+
+#### Scenarios
+
+##### S1 — Dato naive BO-local (TIMESTAMP-AFFECTED) queda en el instante UTC correcto
+- **Given** una columna `createdAt` con valor naive `2026-04-27T20:30:00` (sin timezone, almacenado cuando la sesión era `America/La_Paz`) que representa el instante real `2026-04-28T00:30:00Z` (UTC)
+- **When** se aplica `ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3) USING "createdAt" AT TIME ZONE 'America/La_Paz'`
+- **Then** el valor migrado se almacena como `2026-04-28T00:30:00.000+00` (UTC real) y al leerlo con node-postgres, `createdAt.toISOString()` retorna `"2026-04-28T00:30:00.000Z"`
+
+##### S2 — Dato UTC-noon (UTC-NOON) no sufre shift horario
+- **Given** una columna `date` con valor `2026-04-27T12:00:00` (sin timezone, almacenado via `toNoonUtc()` como UTC-noon)
+- **When** se aplica `ALTER COLUMN "date" TYPE TIMESTAMPTZ(3) USING "date" AT TIME ZONE 'UTC'`
+- **Then** el valor migrado se almacena como `2026-04-27T12:00:00.000+00` (UTC, sin modificación) y al leerlo, `date.toISOString()` retorna `"2026-04-27T12:00:00.000Z"` — idéntico al valor original
+
+##### S3 — Casting implícito de Postgres NO debe aplicarse
+- **Given** el SQL generado por `prisma migrate dev --create-only` para una columna `DateTime`
+- **When** se inspecciona el archivo SQL antes de aplicar
+- **Then** NO existe ningún `ALTER COLUMN ... TYPE TIMESTAMPTZ(3)` sin su cláusula `USING` — el casting implícito `TIMESTAMP → TIMESTAMPTZ` que Postgres aplica por default (que asume UTC) es incorrecto para datos naive BO-local y está prohibido en esta migración
+
+##### S4 — La migración es atómica: fallo de un ALTER revierte todo
+- **Given** el archivo SQL de migración contiene `N` sentencias `ALTER TABLE`
+- **When** cualquiera de ellas falla durante `prisma migrate dev`
+- **Then** toda la migración hace rollback completo — ninguna tabla queda parcialmente migrada
+
+---
+
+### REQ-TZ.3 — El SQL de migración categoriza explícitamente cada columna
+
+El archivo SQL de migración generado DEBE distinguir visualmente y estructuralmente las dos categorías de `USING`. La categorización DEBE ser verificable por inspección directa del archivo SQL — no implícita ni ambigua.
+
+#### Scenarios
+
+##### S1 — Columnas TIMESTAMP-AFFECTED usan `AT TIME ZONE 'America/La_Paz'`
+- **Given** el archivo SQL de migración `timestamptz_migration`
+- **When** se grep por `AT TIME ZONE 'America/La_Paz'`
+- **Then** se obtienen exactamente los `ALTER` correspondientes a las 48 columnas TIMESTAMP-AFFECTED — no más, no menos
+
+##### S2 — Columnas UTC-NOON usan `AT TIME ZONE 'UTC'`
+- **Given** el archivo SQL de migración `timestamptz_migration`
+- **When** se grep por `AT TIME ZONE 'UTC'`
+- **Then** se obtienen exactamente los `ALTER` correspondientes a las 17 columnas UTC-NOON — no más, no menos
+
+##### S3 — Ningún ALTER carece de cláusula USING
+- **Given** el archivo SQL de migración
+- **When** se cuenta el total de `ALTER COLUMN ... TYPE TIMESTAMPTZ`
+- **Then** el total es exactamente 65 y cada uno contiene exactamente una cláusula `USING`
+
+---
+
+### REQ-TZ.4 — El schema Prisma refleja `@db.Timestamptz(3)` en los 65 campos
+
+`prisma/schema.prisma` DEBE agregar la anotación `@db.Timestamptz(3)` a cada campo `DateTime` (y `DateTime?`). Esta anotación es el contrato Prisma que garantiza que `prisma migrate dev` genere `TIMESTAMPTZ(3)` en futuros cambios y que el cliente Prisma interprete correctamente el OID `1184` de PostgreSQL.
+
+#### Scenarios
+
+##### S1 — `@db.Timestamptz(3)` presente en cada campo DateTime
+- **Given** `prisma/schema.prisma` post-cambio
+- **When** se grep por `DateTime` en el schema
+- **Then** cada ocurrencia es `DateTime @db.Timestamptz(3)` o `DateTime? @db.Timestamptz(3)` — ninguna queda sin la anotación `@db`
+
+##### S2 — `prisma generate` no produce errores de tipo
+- **Given** el schema con los 65 campos anotados con `@db.Timestamptz(3)`
+- **When** se ejecuta `prisma generate`
+- **Then** el comando termina con exit code 0 y el cliente generado tipa los campos como `Date` de JavaScript
+
+##### S3 — Nuevas escrituras post-migración se almacenan correctamente
+- **Given** el schema migrado y la DB con columnas `TIMESTAMPTZ(3)`
+- **When** se crea una nueva entidad (ej. `prisma.sale.create(...)`) con `date: new Date("2026-05-01T12:00:00Z")`
+- **Then** el valor se almacena en la columna `TIMESTAMPTZ(3)` como `2026-05-01T12:00:00.000+00` y al leerlo con Prisma retorna `new Date("2026-05-01T12:00:00.000Z")`
+
+---
+
+### REQ-TZ.5 — El trigger `audit_trigger_fn()` no requiere modificación
+
+Los triggers PostgreSQL existentes que usan `NOW()` para poblar `audit_logs.createdAt` DEBEN seguir funcionando sin cambios de código. La migración a `TIMESTAMPTZ(3)` en la columna receptora es suficiente para que `NOW()` (que retorna `TIMESTAMPTZ` nativo) se almacene correctamente.
+
+#### Scenarios
+
+##### S1 — INSERT via trigger post-migración almacena instante UTC real
+- **Given** la columna `audit_logs.createdAt` ha sido migrada a `TIMESTAMPTZ(3)`
+- **When** un trigger `audit_trigger_fn()` se dispara por una mutación en `sales`
+- **Then** la fila de `audit_logs` insertada tiene `createdAt` como un instante `TIMESTAMPTZ` que representa el momento UTC real de la operación
+
+##### S2 — El mismo `audit_trigger_fn()` funciona sin cambios de código SQL
+- **Given** la función `audit_trigger_fn()` en las migraciones anteriores usa `NOW()` para `createdAt`
+- **When** se aplica la migración `timestamptz_migration` (sin tocar las funciones trigger)
+- **Then** `audit_trigger_fn()` sigue compilando y ejecutándose sin error — no se requieren cambios en la definición de la función
+
+---
+
+## Out of Scope (no speccable en este cambio)
+
+| Item | Justificación |
+|------|---------------|
+| Cambio del TZ de sesión de Postgres | No es necesario: `TIMESTAMPTZ` es inmune al timezone de sesión para el almacenamiento |
+| Refactor de `toNoonUtc()` | La función sigue siendo válida para nuevas escrituras de fechas calendario |
+| Normalización de `dueDate` en `receivables.repository.ts` (agregar `toNoonUtc()`) | Deuda técnica separada; no es parte de la migración de tipo |
+| Eliminación del patrón UTC-noon | Cambio de semántica que requiere su propio SDD |
+| Tests de integración contra PostgreSQL real | Cambio de infraestructura de testing fuera del scope |
+| Seed data con timestamps | No existe `prisma/seed.ts` actualmente |
+| Resolución de `TZ=America/La_Paz` en el proceso server-side (`startOfMonth`/`endOfMonth`) | Deuda técnica separada documentada en `lib/date-utils.ts` |
+
+---
+
+## Traceability — Proposal → REQs
+
+| Sección del proposal | REQ |
+|---------------------|-----|
+| Intent — bug de -4h por naive-local | REQ-TZ.1 (S3, S5) |
+| Scope — 65 columnas a TIMESTAMPTZ | REQ-TZ.1 (S1, S2, S4), REQ-TZ.4 |
+| Approach — Paso 1 (schema Prisma) | REQ-TZ.4 |
+| Approach — Paso 2 (SQL generado incorrecto) | REQ-TZ.2 (S3) |
+| Approach — Paso 3 (edición manual del SQL con USING) | REQ-TZ.2 (S1, S2), REQ-TZ.3 |
+| Approach — Paso 5 (migración atómica) | REQ-TZ.2 (S4) |
+| Invariante técnico crítico (dos USING distintos) | REQ-TZ.2, REQ-TZ.3 |
+| R2 — trigger `NOW()` no se rompe | REQ-TZ.5 |

--- a/openspec/changes/timestamptz-migration/specs/persistence-timezone/spec.md
+++ b/openspec/changes/timestamptz-migration/specs/persistence-timezone/spec.md
@@ -14,8 +14,8 @@ La migración lleva las 65 columnas `DateTime` del schema a `TIMESTAMPTZ(3)`. El
 
 | Categoría | Columnas | Cláusula USING |
 |-----------|----------|----------------|
-| **TIMESTAMP-AFFECTED** | 48 columnas (todos los `createdAt`, `updatedAt`, `closedAt`, `windowStart`, `deactivatedAt`) | `USING "col" AT TIME ZONE 'America/La_Paz'` |
-| **UTC-NOON** | 17 columnas (`Sale.date`, `Purchase.date`, `Dispatch.date`, `Payment.date`, `JournalEntry.date`, `FiscalPeriod.startDate/endDate`, `ChickenLot.startDate/endDate`, `Expense.date`, `MortalityLog.date`, `PurchaseDetail.fecha`, `IvaPurchaseBook.fechaFactura`, `IvaSalesBook.fechaFactura`, `AccountsReceivable.dueDate`, `AccountsPayable.dueDate`) | `USING "col" AT TIME ZONE 'UTC'` |
+| **TIMESTAMP-AFFECTED** | 49 columnas (todos los `createdAt`, `updatedAt`, `closedAt`, `windowStart`, `deactivatedAt`) | `USING "col" AT TIME ZONE 'America/La_Paz'` |
+| **UTC-NOON** | 16 columnas (`Sale.date`, `Purchase.date`, `Dispatch.date`, `Payment.date`, `JournalEntry.date`, `FiscalPeriod.startDate/endDate`, `ChickenLot.startDate/endDate`, `Expense.date`, `MortalityLog.date`, `PurchaseDetail.fecha`, `IvaPurchaseBook.fechaFactura`, `IvaSalesBook.fechaFactura`, `AccountsReceivable.dueDate`, `AccountsPayable.dueDate`) | `USING "col" AT TIME ZONE 'UTC'` |
 
 > **Nota**: la lista exhaustiva de las 65 columnas con su categoría está en `design.md` (Inventario columna-por-columna — Tabla canónica). Esa tabla es la fuente canónica para la generación del SQL.
 
@@ -97,12 +97,12 @@ El archivo SQL de migración generado DEBE distinguir visualmente y estructuralm
 ##### S1 — Columnas TIMESTAMP-AFFECTED usan `AT TIME ZONE 'America/La_Paz'`
 - **Given** el archivo SQL de migración `timestamptz_migration`
 - **When** se grep por `AT TIME ZONE 'America/La_Paz'`
-- **Then** se obtienen exactamente los `ALTER` correspondientes a las 48 columnas TIMESTAMP-AFFECTED — no más, no menos
+- **Then** se obtienen exactamente los `ALTER` correspondientes a las 49 columnas TIMESTAMP-AFFECTED — no más, no menos
 
 ##### S2 — Columnas UTC-NOON usan `AT TIME ZONE 'UTC'`
 - **Given** el archivo SQL de migración `timestamptz_migration`
 - **When** se grep por `AT TIME ZONE 'UTC'`
-- **Then** se obtienen exactamente los `ALTER` correspondientes a las 17 columnas UTC-NOON — no más, no menos
+- **Then** se obtienen exactamente los `ALTER` correspondientes a las 16 columnas UTC-NOON — no más, no menos
 
 ##### S3 — Ningún ALTER carece de cláusula USING
 - **Given** el archivo SQL de migración

--- a/openspec/changes/timestamptz-migration/tasks.md
+++ b/openspec/changes/timestamptz-migration/tasks.md
@@ -1,0 +1,919 @@
+# Tasks: timestamptz-migration
+
+**Change**: `timestamptz-migration`
+**Fecha**: 2026-04-26
+**Estado**: listo para `sdd-apply`
+**Fuente canónica**: `design.md` (tabla canónica líneas 81-147, 65 columnas)
+
+---
+
+## Resumen ejecutivo
+
+Este cambio migra 65 columnas `DateTime` de Prisma de `TIMESTAMP(3)` a `TIMESTAMPTZ(3)` en PostgreSQL, corrigiendo un bug de -4 horas causado por naive-local storage. Incluye un fix atómico del cast `::timestamp` → `::timestamptz` en el cursor de paginación de `audit.repository.ts`.
+
+**Conteo canónico (NO RE-DEBATIR)**:
+- **Total**: 65 columnas `DateTime`
+- **TIMESTAMP-AFFECTED** (`USING "col" AT TIME ZONE 'America/La_Paz'`): 48 columnas
+- **UTC-NOON** (`USING "col" AT TIME ZONE 'UTC'`): 17 columnas
+
+---
+
+## Fase 1 — Preparación del schema Prisma
+
+> **Pre-condición**: ninguna. Esta fase es el punto de entrada del cambio.
+>
+> **Modo de ejecución recomendado**: detener el servidor Next.js antes de comenzar para evitar conexiones activas durante la migración (ver R-D3 en design.md).
+
+---
+
+### T-1: Agregar `@db.Timestamptz(3)` a las 65 columnas `DateTime` en `prisma/schema.prisma`
+
+**Qué hacer**: Editar `prisma/schema.prisma` y agregar la anotación `@db.Timestamptz(3)` a cada uno de los 65 campos `DateTime` y `DateTime?`, siguiendo la regla mecánica del design:
+
+```
+# Antes:
+createdAt  DateTime @default(now())
+updatedAt  DateTime @updatedAt
+date       DateTime
+endDate    DateTime?
+
+# Después:
+createdAt  DateTime @db.Timestamptz(3) @default(now())
+updatedAt  DateTime @db.Timestamptz(3) @updatedAt
+date       DateTime @db.Timestamptz(3)
+endDate    DateTime? @db.Timestamptz(3)
+```
+
+**Regla**: la anotación `@db.Timestamptz(3)` va siempre:
+- Después del tipo (`DateTime` o `DateTime?`)
+- Antes de cualquier otro modificador (`@default`, `@updatedAt`, `@map`)
+
+**Lista completa de (modelo, campo, línea schema.prisma)** — usar la tabla canónica de `design.md` líneas 81-147:
+
+| Modelo | Campo | Línea aprox. | Categoría |
+|--------|-------|-------------|-----------|
+| Organization | createdAt | 18 | TIMESTAMP-AFFECTED |
+| CustomRole | createdAt | 60 | TIMESTAMP-AFFECTED |
+| CustomRole | updatedAt | 61 | TIMESTAMP-AFFECTED |
+| OrganizationMember | deactivatedAt | 74 | TIMESTAMP-AFFECTED |
+| User | createdAt | 89 | TIMESTAMP-AFFECTED |
+| Document | createdAt | 121 | TIMESTAMP-AFFECTED |
+| ChatMessage | createdAt | 150 | TIMESTAMP-AFFECTED |
+| AgentRateLimit | windowStart | 166 | TIMESTAMP-AFFECTED |
+| AgentRateLimit | updatedAt | 168 | TIMESTAMP-AFFECTED |
+| Farm | createdAt | 200 | TIMESTAMP-AFFECTED |
+| Farm | updatedAt | 201 | TIMESTAMP-AFFECTED |
+| ChickenLot | startDate | 216 | UTC-NOON |
+| ChickenLot | endDate | 217 | UTC-NOON |
+| ChickenLot | createdAt | 221 | TIMESTAMP-AFFECTED |
+| ChickenLot | updatedAt | 222 | TIMESTAMP-AFFECTED |
+| Expense | date | 238 | UTC-NOON |
+| Expense | createdAt | 242 | TIMESTAMP-AFFECTED |
+| MortalityLog | date | 257 | UTC-NOON |
+| MortalityLog | createdAt | 261 | TIMESTAMP-AFFECTED |
+| JournalEntry | date | 362 | UTC-NOON |
+| JournalEntry | createdAt | 374 | TIMESTAMP-AFFECTED |
+| JournalEntry | updatedAt | 375 | TIMESTAMP-AFFECTED |
+| FiscalPeriod | startDate | 422 | UTC-NOON |
+| FiscalPeriod | endDate | 423 | UTC-NOON |
+| FiscalPeriod | closedAt | 425 | TIMESTAMP-AFFECTED |
+| FiscalPeriod | createdAt | 428 | TIMESTAMP-AFFECTED |
+| FiscalPeriod | updatedAt | 429 | TIMESTAMP-AFFECTED |
+| Contact | createdAt | 578 | TIMESTAMP-AFFECTED |
+| Contact | updatedAt | 579 | TIMESTAMP-AFFECTED |
+| AccountsReceivable | dueDate | 604 | UTC-NOON |
+| AccountsReceivable | createdAt | 610 | TIMESTAMP-AFFECTED |
+| AccountsReceivable | updatedAt | 611 | TIMESTAMP-AFFECTED |
+| AccountsPayable | dueDate | 633 | UTC-NOON |
+| AccountsPayable | createdAt | 639 | TIMESTAMP-AFFECTED |
+| AccountsPayable | updatedAt | 640 | TIMESTAMP-AFFECTED |
+| OrgSettings | createdAt | 675 | TIMESTAMP-AFFECTED |
+| OrgSettings | updatedAt | 676 | TIMESTAMP-AFFECTED |
+| Dispatch | date | 689 | UTC-NOON |
+| Dispatch | createdAt | 707 | TIMESTAMP-AFFECTED |
+| Dispatch | updatedAt | 708 | TIMESTAMP-AFFECTED |
+| ProductType | createdAt | 754 | TIMESTAMP-AFFECTED |
+| ProductType | updatedAt | 755 | TIMESTAMP-AFFECTED |
+| Payment | date | 770 | UTC-NOON |
+| Payment | createdAt | 781 | TIMESTAMP-AFFECTED |
+| Payment | updatedAt | 782 | TIMESTAMP-AFFECTED |
+| OperationalDocType | createdAt | 804 | TIMESTAMP-AFFECTED |
+| OperationalDocType | updatedAt | 805 | TIMESTAMP-AFFECTED |
+| Purchase | date | 821 | UTC-NOON |
+| Purchase | createdAt | 842 | TIMESTAMP-AFFECTED |
+| Purchase | updatedAt | 843 | TIMESTAMP-AFFECTED |
+| PurchaseDetail | fecha | 867 | UTC-NOON |
+| Sale | date | 915 | UTC-NOON |
+| Sale | createdAt | 925 | TIMESTAMP-AFFECTED |
+| Sale | updatedAt | 926 | TIMESTAMP-AFFECTED |
+| AuditLog | createdAt | 970 | TIMESTAMP-AFFECTED |
+| IvaPurchaseBook | fechaFactura | 988 | UTC-NOON |
+| IvaPurchaseBook | createdAt | 1012 | TIMESTAMP-AFFECTED |
+| IvaPurchaseBook | updatedAt | 1013 | TIMESTAMP-AFFECTED |
+| IvaSalesBook | fechaFactura | 1028 | UTC-NOON |
+| IvaSalesBook | createdAt | 1052 | TIMESTAMP-AFFECTED |
+| IvaSalesBook | updatedAt | 1053 | TIMESTAMP-AFFECTED |
+| OrgProfile | createdAt | 1097 | TIMESTAMP-AFFECTED |
+| OrgProfile | updatedAt | 1098 | TIMESTAMP-AFFECTED |
+| DocumentSignatureConfig | createdAt | 1110 | TIMESTAMP-AFFECTED |
+| DocumentSignatureConfig | updatedAt | 1111 | TIMESTAMP-AFFECTED |
+
+**Archivo afectado**: `prisma/schema.prisma`
+
+**Verificación de completion**: ver T-2 a continuación.
+
+---
+
+### T-2: Verificar que ningún campo `DateTime` queda sin `@db.Timestamptz(3)`
+
+**Qué hacer**: Después de editar el schema, ejecutar los siguientes greps de verificación:
+
+```bash
+# Grep 1 — Ningún DateTime sin la anotación (resultado esperado: 0 líneas)
+grep "DateTime" prisma/schema.prisma | grep -v "@db.Timestamptz"
+# Esperado: 0 líneas
+
+# Grep 2 — Contar que son exactamente 65 los annotados
+grep "DateTime" prisma/schema.prisma | grep "@db.Timestamptz(3)" | wc -l
+# Esperado: 65
+```
+
+**Criterio de completion**:
+- El primer grep devuelve `0 líneas` (o salida vacía)
+- El segundo grep devuelve `65`
+- Si cualquiera falla, T-3 NO se ejecuta: volver a T-1 y corregir las omisiones
+
+---
+
+### Commit A: schema Prisma
+
+```
+feat(prisma): annotate DateTime fields with @db.Timestamptz(3)
+
+Adds @db.Timestamptz(3) to all 65 DateTime columns in schema.prisma.
+This makes the Prisma contract explicit: every temporal column maps
+to TIMESTAMPTZ(3) in PostgreSQL. No migration is applied yet.
+```
+
+---
+
+## Fase 2 — Generación y edición del SQL de migración
+
+> **Pre-condición**: T-2 completado con los 2 greps reportando OK (0 líneas sin anotación, 65 anotadas).
+
+---
+
+### T-3: Generar el SQL base con `prisma migrate dev --create-only`
+
+**Qué hacer**: Ejecutar el siguiente comando para que Prisma genere el archivo SQL sin aplicarlo:
+
+```bash
+pnpm prisma migrate dev --create-only --name timestamptz_migration
+```
+
+**Resultado esperado**:
+- Se crea el directorio `prisma/migrations/<timestamp>_timestamptz_migration/`
+- Dentro hay un `migration.sql` con exactamente 65 sentencias de la forma:
+  ```sql
+  ALTER TABLE "<table_name>" ALTER COLUMN "<col_name>" TYPE TIMESTAMPTZ(3);
+  ```
+- **El SQL generado es INCORRECTO** — Prisma genera los ALTER sin cláusula `USING`. NO aplicar todavía.
+- El timestamp del directorio se autogenera (ej. `20260427120000_timestamptz_migration`)
+
+**Criterio de completion**: el archivo `prisma/migrations/*_timestamptz_migration/migration.sql` existe y se puede abrir.
+
+**Nota**: si Prisma reporta "no hay cambios pendientes", verificar que T-1/T-2 fueron completados y que el schema fue guardado correctamente. Verificar también que `PRISMA_CLIENT_NO_RETRY=1` no está interfiriendo.
+
+---
+
+### T-4: Editar el SQL — agregar `USING AT TIME ZONE 'America/La_Paz'` a las 48 columnas TIMESTAMP-AFFECTED
+
+**Qué hacer**: Abrir `prisma/migrations/*_timestamptz_migration/migration.sql` y reescribir cada `ALTER COLUMN` de las 48 columnas TIMESTAMP-AFFECTED para que tenga el formato correcto:
+
+```sql
+ALTER TABLE "<table_name>"
+  ALTER COLUMN "<column_name>" TYPE TIMESTAMPTZ(3)
+  USING "<column_name>" AT TIME ZONE 'America/La_Paz';
+```
+
+**Lista completa de las 48 columnas TIMESTAMP-AFFECTED** (tabla SQL → columna):
+
+```
+organizations            → createdAt
+custom_roles             → createdAt, updatedAt
+organization_members     → deactivatedAt
+users                    → createdAt
+documents                → createdAt
+chat_messages            → createdAt
+agent_rate_limits        → windowStart, updatedAt
+farms                    → createdAt, updatedAt
+chicken_lots             → createdAt, updatedAt
+expenses                 → createdAt
+mortality_logs           → createdAt
+journal_entries          → createdAt, updatedAt
+fiscal_periods           → closedAt, createdAt, updatedAt
+contacts                 → createdAt, updatedAt
+accounts_receivable      → createdAt, updatedAt
+accounts_payable         → createdAt, updatedAt
+org_settings             → createdAt, updatedAt
+dispatches               → createdAt, updatedAt
+product_types            → createdAt, updatedAt
+payments                 → createdAt, updatedAt
+operational_doc_types    → createdAt, updatedAt
+purchases                → createdAt, updatedAt
+sales                    → createdAt, updatedAt
+audit_logs               → createdAt
+iva_purchase_books       → createdAt, updatedAt
+iva_sales_books          → createdAt, updatedAt
+org_profile              → createdAt, updatedAt
+document_signature_configs → createdAt, updatedAt
+```
+
+**Referencia de nombres de tabla**: ver tabla "Mapeo tabla SQL → modelo Prisma" en `design.md`.
+
+**Verificación de completion**: ver T-7 (gate bloqueante de Fase 3).
+
+---
+
+### T-5: Editar el SQL — agregar `USING AT TIME ZONE 'UTC'` a las 17 columnas UTC-NOON
+
+**Qué hacer**: En el mismo archivo `migration.sql`, reescribir cada `ALTER COLUMN` de las 17 columnas UTC-NOON:
+
+```sql
+ALTER TABLE "<table_name>"
+  ALTER COLUMN "<column_name>" TYPE TIMESTAMPTZ(3)
+  USING "<column_name>" AT TIME ZONE 'UTC';
+```
+
+**Lista completa de las 17 columnas UTC-NOON** (tabla SQL → columna):
+
+```
+chicken_lots          → startDate, endDate
+expenses              → date
+mortality_logs        → date
+journal_entries       → date
+fiscal_periods        → startDate, endDate
+accounts_receivable   → dueDate
+accounts_payable      → dueDate
+dispatches            → date
+payments              → date
+purchases             → date
+purchase_details      → fecha   ← nullable (DateTime?); USING maneja NULL correctamente
+sales                 → date
+iva_purchase_books    → fechaFactura
+iva_sales_books       → fechaFactura
+```
+
+**Nota sobre `purchase_details.fecha`**: es `DateTime?` (nullable). La cláusula `USING "fecha" AT TIME ZONE 'UTC'` en PostgreSQL trata NULL como NULL — la conversión es segura.
+
+**Verificación de completion**: ver T-9 y T-10 (gates bloqueantes de Fase 3).
+
+---
+
+### T-6: Reorganizar el SQL con estructura por sección y comentarios de categoría
+
+**Qué hacer**: Reorganizar el contenido del `migration.sql` editado para que quede con la siguiente estructura de secciones (facilita revisión visual y reduce riesgo de confundir categorías):
+
+```sql
+-- ============================================================
+-- TIMESTAMP-AFFECTED: datos naive BO-local → USING 'America/La_Paz'
+-- (48 columnas — representan instantes reales en el tiempo)
+-- ============================================================
+
+-- organizations
+ALTER TABLE "organizations"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+
+-- custom_roles
+ALTER TABLE "custom_roles"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "custom_roles"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- ... (resto de columnas TIMESTAMP-AFFECTED, una tabla por bloque con comentario)
+
+-- ============================================================
+-- UTC-NOON: datos ya en UTC vía toNoonUtc() → USING 'UTC'
+-- (17 columnas — representan fechas calendario como TIMESTAMPTZ)
+-- ============================================================
+
+-- chicken_lots
+ALTER TABLE "chicken_lots"
+  ALTER COLUMN "startDate" TYPE TIMESTAMPTZ(3)
+  USING "startDate" AT TIME ZONE 'UTC';
+ALTER TABLE "chicken_lots"
+  ALTER COLUMN "endDate" TYPE TIMESTAMPTZ(3)
+  USING "endDate" AT TIME ZONE 'UTC';
+
+-- ... (resto de columnas UTC-NOON)
+```
+
+**Criterio de completion**: el archivo editado tiene las dos secciones con comentarios de encabezado, y cada tabla tiene un comentario `-- <table_name>` antes de sus ALTER.
+
+---
+
+## Fase 3 — GATE BLOQUEANTE pre-apply (4 greps obligatorios)
+
+> **INVARIANTE**: Los cuatro greps de esta fase son condición necesaria y suficiente para autorizar la ejecución de T-11.
+>
+> **La fase 4 (T-11) NO puede marcarse `completed` ni ejecutarse si cualquiera de los greps T-7, T-8, T-9 o T-10 no reporta el resultado esperado.**
+>
+> Si algún grep falla: DETENER, no ejecutar T-11, investigar la discrepancia en el SQL editado, corregirla, y volver a correr los 4 greps desde T-7.
+
+---
+
+### T-7: Grep #1 — Total de `ALTER COLUMN` debe ser exactamente 65 (BLOQUEANTE)
+
+**Comando exacto**:
+```bash
+grep -c "ALTER COLUMN" prisma/migrations/*_timestamptz_migration/migration.sql
+```
+
+**Resultado esperado**: `65`
+
+> **BLOQUEANTE** — Si este grep reporta cualquier número distinto de `65`, NO ejecutar T-11. El SQL tiene columnas faltantes (< 65) o duplicadas (> 65). Investigar y corregir antes de continuar.
+
+**Criterio de completion**: el comando imprime `65` y termina con exit code 0.
+
+---
+
+### T-8: Grep #2 — Ningún `ALTER COLUMN` sin cláusula `USING` (BLOQUEANTE)
+
+**Comando exacto**:
+```bash
+grep "TYPE TIMESTAMPTZ" prisma/migrations/*_timestamptz_migration/migration.sql | grep -v "USING"
+```
+
+**Resultado esperado**: `0 líneas` (salida vacía — el comando no imprime nada)
+
+> **BLOQUEANTE** — Si este grep imprime cualquier línea, existe al menos un `ALTER COLUMN ... TYPE TIMESTAMPTZ` sin su cláusula `USING`. Esas líneas permiten el casting implícito de Postgres que asume UTC, lo cual corrompería los datos naive BO-local. NO ejecutar T-11. Agregar la cláusula `USING` correcta a cada línea reportada.
+
+**Criterio de completion**: el comando no produce output (salida vacía), exit code 1 es aceptable (grep devuelve 1 cuando no hay matches).
+
+---
+
+### T-9: Grep #3 — Count `USING 'America/La_Paz'` debe ser exactamente 48 (BLOQUEANTE)
+
+**Comando exacto**:
+```bash
+grep -c "AT TIME ZONE 'America/La_Paz'" prisma/migrations/*_timestamptz_migration/migration.sql
+```
+
+**Resultado esperado**: `48`
+
+> **BLOQUEANTE** — Si este grep reporta cualquier número distinto de `48`, la distribución de cláusulas TIMESTAMP-AFFECTED está incorrecta. Puede significar que alguna columna TIMESTAMP-AFFECTED quedó con `USING 'UTC'` (error grave: corrompería datos) o viceversa. NO ejecutar T-11. Auditar las 48 columnas contra la lista canónica de T-4.
+
+**Criterio de completion**: el comando imprime `48` y termina con exit code 0.
+
+---
+
+### T-10: Grep #4 — Count `USING 'UTC'` debe ser exactamente 17 (BLOQUEANTE)
+
+**Comando exacto**:
+```bash
+grep -c "AT TIME ZONE 'UTC'" prisma/migrations/*_timestamptz_migration/migration.sql
+```
+
+**Resultado esperado**: `17`
+
+> **BLOQUEANTE** — Si este grep reporta cualquier número distinto de `17`, la distribución de cláusulas UTC-NOON está incorrecta. NO ejecutar T-11. Auditar las 17 columnas contra la lista canónica de T-5.
+
+**Verificación cruzada adicional** (suma): los resultados de T-9 y T-10 deben sumar 65. Si `48 + 17 ≠ 65`, hay un error de conteo que debe resolverse antes de continuar.
+
+**Criterio de completion**: el comando imprime `17` y termina con exit code 0, y la suma con T-9 es 65.
+
+---
+
+## Fase 4 — Aplicación de la migración
+
+> **PRE-CONDICIÓN BLOQUEANTE**: Fase 3 completada con los 4 greps reportando OK:
+> - T-7: `65`
+> - T-8: `0 líneas` (salida vacía)
+> - T-9: `48`
+> - T-10: `17`
+>
+> **Sin esta pre-condición, T-11 NO se ejecuta bajo ninguna circunstancia.**
+>
+> También recomendado: servidor Next.js detenido para evitar conexiones activas que puedan competir por el lock de ALTER TABLE (ver R-D3 en design.md).
+
+---
+
+### T-11: Aplicar la migración con `prisma migrate dev`
+
+**Qué hacer**: Ejecutar la migración sin `--create-only`:
+
+```bash
+pnpm prisma migrate dev
+```
+
+**Resultado esperado**:
+- Prisma detecta el archivo `.sql` pendiente y lo aplica
+- PostgreSQL ejecuta los 65 `ALTER TABLE ... ALTER COLUMN` en una única transacción
+- Prisma reporta `Your database is now in sync with your schema.`
+- No hay errores de tipo, lock timeout, ni rollback
+
+**Si la migración falla**:
+- PostgreSQL hace rollback completo — ninguna tabla queda parcialmente migrada (atomicidad garantizada por DDL transaccional de Postgres, ver R-D1 en design.md)
+- Inspeccionar el error: si es de tipo `could not find operator` o `invalid input syntax`, revisar la cláusula `USING` del ALTER que falló
+- NO re-ejecutar hasta corregir el SQL
+
+**Criterio de completion**: `pnpm prisma migrate dev` termina con exit code 0 y mensaje de sincronización.
+
+---
+
+### Commit B: migración SQL
+
+```
+feat(db): migrate DateTime columns to TIMESTAMPTZ(3)
+
+Applies timestamptz_migration: 65 ALTER TABLE statements converting
+all DateTime columns from TIMESTAMP(3) to TIMESTAMPTZ(3).
+
+- 48 TIMESTAMP-AFFECTED columns use USING AT TIME ZONE 'America/La_Paz'
+  (naive BO-local data → correct UTC instant)
+- 17 UTC-NOON columns use USING AT TIME ZONE 'UTC'
+  (dates stored as UTC-noon via toNoonUtc() → preserved without shift)
+
+Fixes a -4h display bug caused by node-postgres misreading naive-local
+timestamps as UTC.
+```
+
+---
+
+## Fase 5 — Test de regresión TDD para el cursor audit (RED → GREEN)
+
+> **Pre-condición**: Fase 4 completada (migración aplicada, DB en TIMESTAMPTZ). Fase 6 (fix del código) viene DESPUÉS de esta fase — el test se escribe primero en RED, luego se aplica el fix en Fase 6.
+>
+> **Justificación TDD**: el fix en `audit.repository.ts` es un cambio de comportamiento verificable. Se escribe el test que documenta el comportamiento correcto ANTES del fix, se verifica que falla (RED) por la razón correcta (cast incorrecto), y luego el fix lo pone en GREEN.
+
+---
+
+### T-12: Escribir tests de regresión para el cursor `::timestamptz` (RED — deben fallar antes del fix)
+
+**Qué hacer**: Agregar un nuevo bloque `describe` al final del archivo `features/audit/__tests__/audit.repository.test.ts` con los siguientes tests que cubren los scenarios A1-S7, A1-S8, y A1-S9 de la spec `audit-module`:
+
+**Tests a agregar**:
+
+```typescript
+describe("AuditRepository.listFlat — cursor timestamptz cross-medianoche (A1-S7, A1-S8, A1-S9)", () => {
+  /**
+   * A1-S7: cursor serializado en UTC (ISO Z) compara correctamente con columna TIMESTAMPTZ.
+   *
+   * Setup: 3 filas con createdAt en UTC — una antes y dos después de un cursor fijo.
+   * El cursor apunta a 2026-04-27T04:00:00.000Z (medianoche BO-local).
+   * La página 2 debe devolver exactamente las filas anteriores al cursor, sin shift.
+   */
+  it("cursor ISO-Z compara correctamente con TIMESTAMPTZ — no hay shift de 4h (A1-S7)", async () => {
+    // Timestamps fijos en UTC — simula un rango cross-medianoche UTC
+    const tBefore1 = new Date("2026-04-27T03:50:00.000Z"); // antes del cursor
+    const tBefore2 = new Date("2026-04-27T03:55:00.000Z"); // antes del cursor
+    const tAfter   = new Date("2026-04-27T04:05:00.000Z"); // después del cursor (primera página)
+
+    await seedAuditRows([
+      {
+        id: "cursor-after-1",
+        organizationId: orgAId,
+        entityType: "sales",
+        entityId: "sale_tz_after",
+        action: "CREATE",
+        changedById: userAId,
+        createdAt: tAfter,
+      },
+      {
+        id: "cursor-before-1",
+        organizationId: orgAId,
+        entityType: "sales",
+        entityId: "sale_tz_before1",
+        action: "CREATE",
+        changedById: userAId,
+        createdAt: tBefore2,
+      },
+      {
+        id: "cursor-before-2",
+        organizationId: orgAId,
+        entityType: "sales",
+        entityId: "sale_tz_before2",
+        action: "CREATE",
+        changedById: userAId,
+        createdAt: tBefore1,
+      },
+    ]);
+
+    const repo = new AuditRepository();
+
+    // Página 1: trae la fila más reciente (tAfter)
+    const page1 = await repo.listFlat(orgAId, {
+      dateFrom: new Date("2026-04-27T00:00:00.000Z"),
+      dateTo:   new Date("2026-04-27T23:59:59.999Z"),
+      limit: 1,
+    });
+
+    expect(page1.rows).toHaveLength(1);
+    expect(page1.rows[0].id).toBe("cursor-after-1");
+    expect(page1.nextCursor).not.toBeNull();
+
+    // El cursor codifica el instante UTC real de tAfter
+    const cursorTs = new Date(page1.nextCursor!.createdAt);
+    expect(cursorTs.toISOString()).toBe(tAfter.toISOString());
+
+    // Página 2: debe traer las 2 filas anteriores al cursor sin shift
+    const page2 = await repo.listFlat(orgAId, {
+      dateFrom: new Date("2026-04-27T00:00:00.000Z"),
+      dateTo:   new Date("2026-04-27T23:59:59.999Z"),
+      limit: 10,
+      cursor: page1.nextCursor!,
+    });
+
+    // Con ::timestamp (bug): el cursor ISO-Z pierde timezone y Postgres lo trata
+    // como local, produciendo un shift de +4h → las filas "antes" quedan fuera del rango.
+    // Con ::timestamptz (fix): la comparación es UTC-to-UTC, resultado correcto.
+    expect(page2.rows).toHaveLength(2);
+    const page2Ids = page2.rows.map((r: AuditRow) => r.id);
+    expect(page2Ids).toContain("cursor-before-1");
+    expect(page2Ids).toContain("cursor-before-2");
+    expect(page2Ids).not.toContain("cursor-after-1");
+  });
+
+  /**
+   * A1-S8: paginación cross-medianoche UTC mantiene orden estable.
+   *
+   * Filas que cruzan la medianoche UTC (00:00:00Z) deben aparecer exactamente
+   * una vez y en orden DESC. Con ::timestamp, la medianoche UTC equivale a
+   * 20:00 BO-local, donde el shift puede causar duplicados o pérdidas.
+   */
+  it("paginación cross-medianoche UTC — todas las filas aparecen exactamente una vez (A1-S8)", async () => {
+    const rows: { id: string; createdAt: Date }[] = [
+      { id: "cm-1", createdAt: new Date("2026-04-26T23:50:00.000Z") },
+      { id: "cm-2", createdAt: new Date("2026-04-26T23:55:00.000Z") },
+      { id: "cm-3", createdAt: new Date("2026-04-27T00:05:00.000Z") },
+      { id: "cm-4", createdAt: new Date("2026-04-27T00:10:00.000Z") },
+    ];
+
+    await seedAuditRows(
+      rows.map((r) => ({
+        id: r.id,
+        organizationId: orgAId,
+        entityType: "sales",
+        entityId: `sale_cm_${r.id}`,
+        action: "CREATE",
+        changedById: userAId,
+        createdAt: r.createdAt,
+      })),
+    );
+
+    const repo = new AuditRepository();
+    const allIds: string[] = [];
+
+    // Paginar de a 1 para forzar múltiples cursors
+    let cursor = null;
+    for (let page = 0; page < 5; page++) {
+      const result = await repo.listFlat(orgAId, {
+        dateFrom: new Date("2026-04-26T23:00:00.000Z"),
+        dateTo:   new Date("2026-04-27T01:00:00.000Z"),
+        limit: 1,
+        cursor: cursor ?? undefined,
+      });
+      if (result.rows.length === 0) break;
+      allIds.push(...result.rows.map((r: AuditRow) => r.id));
+      cursor = result.nextCursor;
+      if (!cursor) break;
+    }
+
+    // Todas las 4 filas deben aparecer exactamente una vez
+    expect(allIds).toHaveLength(4);
+    expect(new Set(allIds).size).toBe(4); // sin duplicados
+    for (const r of rows) {
+      expect(allIds).toContain(r.id);
+    }
+
+    // Orden DESC: cm-4 > cm-3 > cm-2 > cm-1
+    expect(allIds[0]).toBe("cm-4");
+    expect(allIds[1]).toBe("cm-3");
+    expect(allIds[2]).toBe("cm-2");
+    expect(allIds[3]).toBe("cm-1");
+  });
+
+  /**
+   * A1-S9 — Verificación negativa: documenta que el bug ::timestamp NO reproduce con el fix.
+   *
+   * Con la columna TIMESTAMPTZ y el cast correcto ::timestamptz, el cursor
+   * '2026-04-27T04:00:00.000Z' (medianoche BO) compara correctamente.
+   * Con ::timestamp (bug), Postgres ignoraría el Z y trataría el valor como
+   * local, causando un offset de +4h (compararía contra las 08:00 UTC en lugar
+   * de las 04:00 UTC), produciendo duplicados o filas faltantes.
+   *
+   * Este test verifica que el comportamiento correcto está presente (no replica el bug).
+   */
+  it("::timestamp bug NO reproduce — medianoche BO-local como cursor no produce offset (A1-S9)", async () => {
+    // Medianoche BO-local = 04:00:00Z UTC
+    const midnightBO = new Date("2026-04-27T04:00:00.000Z");
+    const justBefore = new Date("2026-04-27T03:59:59.000Z"); // 23:59:59 BO del día anterior
+    const justAfter  = new Date("2026-04-27T04:00:01.000Z"); // 00:00:01 BO del día nuevo
+
+    await seedAuditRows([
+      {
+        id: "midnight-before",
+        organizationId: orgAId,
+        entityType: "sales",
+        entityId: "sale_mn_before",
+        action: "CREATE",
+        changedById: userAId,
+        createdAt: justBefore,
+      },
+      {
+        id: "midnight-exact",
+        organizationId: orgAId,
+        entityType: "sales",
+        entityId: "sale_mn_exact",
+        action: "CREATE",
+        changedById: userAId,
+        createdAt: midnightBO,
+      },
+      {
+        id: "midnight-after",
+        organizationId: orgAId,
+        entityType: "sales",
+        entityId: "sale_mn_after",
+        action: "CREATE",
+        changedById: userAId,
+        createdAt: justAfter,
+      },
+    ]);
+
+    const repo = new AuditRepository();
+
+    // Construir cursor manualmente que apunta a midnightBO
+    const cursorAtMidnight = {
+      createdAt: midnightBO.toISOString(), // "2026-04-27T04:00:00.000Z"
+      id: "midnight-exact",
+    };
+
+    const result = await repo.listFlat(orgAId, {
+      dateFrom: new Date("2026-04-26T00:00:00.000Z"),
+      dateTo:   new Date("2026-04-28T00:00:00.000Z"),
+      limit: 10,
+      cursor: cursorAtMidnight,
+    });
+
+    // Con el fix (::timestamptz): la comparación evalúa < 04:00:00Z
+    // Solo debe aparecer justBefore (03:59:59Z).
+    // Con el bug (::timestamp): Postgres ignoraría el Z, aplicaría offset de -4h,
+    // y la comparación fallaría — justBefore podría desaparecer del resultado.
+    expect(result.rows.map((r: AuditRow) => r.id)).toContain("midnight-before");
+    expect(result.rows.map((r: AuditRow) => r.id)).not.toContain("midnight-exact");
+    expect(result.rows.map((r: AuditRow) => r.id)).not.toContain("midnight-after");
+  });
+});
+```
+
+**Archivo afectado**: `features/audit/__tests__/audit.repository.test.ts`
+
+**Verificación RED (antes del fix en T-13)**:
+```bash
+pnpm test features/audit/__tests__/audit.repository.test.ts --reporter=verbose 2>&1 | grep -E "FAIL|✗|cursor timestamptz"
+# Esperado: los 3 tests del bloque "cursor timestamptz cross-medianoche" DEBEN fallar
+# con error de assertion (resultado incorrecto) — no con error de compilación.
+# El failure mode esperado: la paginación cross-medianoche devuelve filas incorrectas
+# porque ::timestamp descarta el timezone del cursor ISO-Z.
+```
+
+**Criterio de completion (RED)**: los 3 tests del bloque `cursor timestamptz cross-medianoche` fallan (assertion error, no compile error), y los tests existentes siguen en verde.
+
+> **Nota**: si los tests pasan en RED antes del fix, puede significar que la DB aún tiene columnas TIMESTAMP o que el test no está cubriendo el comportamiento diferencial. En ese caso, verificar con psql que `audit_logs.createdAt` es efectivamente `timestamp with time zone` post-migración.
+
+---
+
+## Fase 6 — Fix del cursor en `audit.repository.ts`
+
+> **Pre-condición**: T-12 completado y verificado en RED (los 3 tests fallan con la razón correcta).
+
+---
+
+### T-13: Cambiar `::timestamp` → `::timestamptz` en `audit.repository.ts` líneas 95-97
+
+**Archivo**: `features/audit/audit.repository.ts`
+
+**Qué hacer**: Reemplazar las 3 ocurrencias de `::timestamp` en el bloque WHERE de `listFlat` (líneas 95-97):
+
+```typescript
+// ANTES (incorrecto post-migración — líneas 95-97):
+${cursorCreatedAt}::timestamp IS NULL
+OR awp."createdAt" <  ${cursorCreatedAt}::timestamp
+OR (awp."createdAt" = ${cursorCreatedAt}::timestamp AND awp.id < ${cursorId}::text)
+
+// DESPUÉS (correcto con TIMESTAMPTZ):
+${cursorCreatedAt}::timestamptz IS NULL
+OR awp."createdAt" <  ${cursorCreatedAt}::timestamptz
+OR (awp."createdAt" = ${cursorCreatedAt}::timestamptz AND awp.id < ${cursorId}::text)
+```
+
+**Cambio**: exactamente 3 reemplazos de `::timestamp` por `::timestamptz`. No se tocan otros archivos.
+
+**No requieren cambios** (confirmado en design.md):
+- Tipos TypeScript (`cursorCreatedAt` sigue siendo `string | null`)
+- `AuditCursor` interface (sigue siendo `{ createdAt: string; id: string }`)
+- `nextCursor = { createdAt: last.createdAt.toISOString(), id: last.id }` (línea 107) — correcto
+- `getVoucherHistory` — no usa cursor pagination
+
+**Verificación GREEN**:
+```bash
+pnpm test features/audit/__tests__/audit.repository.test.ts --reporter=verbose 2>&1 | grep -E "PASS|✓|cursor timestamptz|FAIL"
+# Esperado: los 3 tests del bloque "cursor timestamptz cross-medianoche" pasan (GREEN)
+# y los tests previos siguen en verde.
+```
+
+**Criterio de completion**: todos los tests de `audit.repository.test.ts` pasan en verde, incluyendo los 3 nuevos del bloque A1-S7/A1-S8/A1-S9.
+
+---
+
+### Commit C: fix del cursor audit
+
+```
+fix(audit): cast cursor as timestamptz for correct pagination
+
+Replaces ::timestamp with ::timestamptz in the listFlat cursor WHERE
+clause (audit.repository.ts:95-97).
+
+With TIMESTAMPTZ(3) columns, ::timestamp discards the timezone from
+the ISO-Z cursor string before comparison, causing a -4h offset at
+Bolivia midnight boundaries (04:00:00Z = 00:00 BO-local). The correct
+cast ::timestamptz preserves timezone semantics and produces accurate
+comparisons.
+
+Regression tests: A1-S7, A1-S8, A1-S9 (audit-module delta spec).
+```
+
+---
+
+## Fase 7 — Verificación post-apply
+
+> **Pre-condición**: Fases 4, 5, 6 completadas. Migración aplicada, tests en verde.
+
+---
+
+### T-14: Verificación de tipo de columnas en PostgreSQL (SQL directo)
+
+**Qué hacer**: Ejecutar las siguientes queries en psql o en un cliente SQL conectado a la DB de desarrollo:
+
+```sql
+-- Query 1: verificar que NO quedan columnas TIMESTAMP sin timezone
+SELECT table_name, column_name, data_type
+FROM information_schema.columns
+WHERE data_type = 'timestamp without time zone'
+  AND table_schema = 'public';
+-- Esperado: 0 filas
+
+-- Query 2: contar columnas TIMESTAMPTZ en las tablas del schema
+SELECT COUNT(*) AS timestamptz_count
+FROM information_schema.columns
+WHERE data_type = 'timestamp with time zone'
+  AND table_schema = 'public'
+  AND table_name IN (
+    'organizations','custom_roles','organization_members','users','documents',
+    'chat_messages','agent_rate_limits','farms','chicken_lots','expenses',
+    'mortality_logs','journal_entries','fiscal_periods','contacts',
+    'accounts_receivable','accounts_payable','org_settings','dispatches',
+    'product_types','payments','operational_doc_types','purchases',
+    'purchase_details','sales','audit_logs','iva_purchase_books',
+    'iva_sales_books','org_profile','document_signature_configs'
+  );
+-- Esperado: 65
+```
+
+**Criterio de completion**: Query 1 devuelve 0 filas, Query 2 devuelve 65.
+
+---
+
+### T-15: Smoke test del módulo audit en la UI
+
+**Qué hacer**: Con el servidor Next.js corriendo (`pnpm dev`), verificar manualmente:
+
+1. Navegar a `/[orgSlug]/audit` — la página carga sin errores 500
+2. Las cards de auditoría muestran hora visible (no solo fecha) que coincide con la hora real en Bolivia
+3. Paginación: hacer scroll o cargar más páginas — verificar que no hay duplicados ni filas faltantes
+4. Verificar un rango de fechas que cruce la medianoche local (ej. 23:50 a 00:10) — todas las filas aparecen en orden correcto
+
+**Criterio de completion**: ningún error en consola relacionado con timezone, la hora mostrada en las cards coincide con el instante real de la operación en `America/La_Paz`.
+
+---
+
+### T-16: TypeScript type-check en verde
+
+**Comando exacto**:
+```bash
+pnpm tsc --noEmit
+```
+
+**Resultado esperado**: exit code 0, 0 errores TypeScript.
+
+**Criterio de completion**: el comando termina con exit code 0.
+
+> **Nota**: el cambio `::timestamp` → `::timestamptz` es en un string SQL dentro de `Prisma.sql` — no afecta tipos TypeScript. El comando debe pasar sin cambios adicionales. Si hay errores, investigar si son pre-existentes o introducidos por el cambio.
+
+---
+
+### T-17: Ejecutar suite de tests completa
+
+**Comando exacto**:
+```bash
+pnpm test
+```
+
+**Resultado esperado**: todos los tests en verde (exit code 0).
+
+**Criterio de completion**: `pnpm test` termina con exit code 0. Si algún test falla, investigar si es pre-existente o introducido por el cambio.
+
+> **Nota**: los tests unitarios del módulo audit usan mocks con timestamps en formato UTC (ej. `new Date("...Z")`). Son correctos con TIMESTAMPTZ — la interfaz TypeScript (`Date`) no cambia, solo el tipo de columna en la DB.
+
+---
+
+## Fase 8 — Documentación en PR
+
+> **Pre-condición**: Fases 1-7 completadas. Esta fase se ejecuta al abrir el PR.
+
+---
+
+### T-18: PR description incluye nota operativa sobre ausencia de pg_dump
+
+**Qué hacer**: En la descripción del PR, incluir la siguiente nota (o equivalente) en una sección "Notas operativas":
+
+```markdown
+## Notas operativas
+
+### Ausencia de pg_dump previo
+
+Esta migración se aplicó **SIN** `pg_dump` previo porque la base de datos
+de desarrollo solo contiene datos de ejemplo generados para testing —
+no hay datos de usuarios reales ni información productiva en riesgo.
+
+**ESTE CRITERIO NO APLICA A PRODUCCIÓN.**
+
+Futuras migraciones que modifiquen tipos de columnas en tablas con datos
+productivos **REQUIEREN** backup previo con `pg_dump` antes de ejecutar
+`prisma migrate dev`. La atomicidad de PostgreSQL (rollback en caso de
+fallo) no reemplaza al backup — protege contra errores de ejecución, no
+contra errores de lógica en la cláusula `USING`.
+
+### Riesgo de lock en producción (R-D2)
+
+`ALTER TABLE ... ALTER COLUMN TYPE` adquiere `ACCESS EXCLUSIVE` lock por
+tabla. Para tablas de alto volumen (ej. `audit_logs` con millones de filas),
+este approach de ALTER directo **no es adecuado para producción** sin una
+ventana de mantenimiento o una estrategia de migración online (pg_repack,
+columna shadow). Documentar y evaluar antes de ejecutar en producción.
+```
+
+**Criterio de completion**: el PR abierto incluye esta nota en su descripción.
+
+---
+
+## Resumen de commits en el PR
+
+| Commit | Fase | Descripción |
+|--------|------|-------------|
+| **Commit A** | Fase 1 | `feat(prisma): annotate DateTime fields with @db.Timestamptz(3)` |
+| **Commit B** | Fase 4 | `feat(db): migrate DateTime columns to TIMESTAMPTZ(3)` |
+| **Commit C** | Fase 6 | `fix(audit): cast cursor as timestamptz for correct pagination` |
+
+> **Nota**: los tests de Fase 5 (T-12) pueden commitearse junto con Commit C o antes, como commit separado. Si se separan:
+> ```
+> test(audit): add regression tests for cursor timestamptz (A1-S7, A1-S8, A1-S9)
+> ```
+
+---
+
+## Mapa de dependencias entre tareas
+
+```
+T-1 → T-2 → [T-2 OK?] → T-3 → T-4 → T-5 → T-6
+                                              ↓
+                                T-7 → T-8 → T-9 → T-10
+                                              ↓
+                                        [4 greps OK?]
+                                              ↓ SÍ
+                                    T-11 (Commit A+B)
+                                              ↓
+                                   T-12 (RED) → T-13 (GREEN, Commit C)
+                                              ↓
+                                T-14 → T-15 → T-16 → T-17
+                                              ↓
+                                            T-18
+```
+
+---
+
+## Checklist de completion por fase
+
+| Fase | Tareas | Gate |
+|------|--------|------|
+| Fase 1 — Schema Prisma | T-1, T-2 | T-2: 0 líneas sin anotación, 65 anotadas |
+| Fase 2 — Generación SQL | T-3, T-4, T-5, T-6 | SQL editado con USING en todos los ALTER |
+| Fase 3 — Gate pre-apply | T-7, T-8, T-9, T-10 | **BLOQUEANTE**: 65 / 0 líneas / 48 / 17 |
+| Fase 4 — Apply | T-11 | `pnpm prisma migrate dev` con exit code 0 |
+| Fase 5 — Tests TDD (RED) | T-12 | 3 tests nuevos fallan en RED (razón correcta) |
+| Fase 6 — Fix cursor | T-13 | Tests pasan en GREEN |
+| Fase 7 — Verificación | T-14, T-15, T-16, T-17 | tsc y pnpm test en verde, DB verified |
+| Fase 8 — PR doc | T-18 | PR incluye nota operativa pg_dump |

--- a/openspec/changes/timestamptz-migration/tasks.md
+++ b/openspec/changes/timestamptz-migration/tasks.md
@@ -13,8 +13,8 @@ Este cambio migra 65 columnas `DateTime` de Prisma de `TIMESTAMP(3)` a `TIMESTAM
 
 **Conteo canónico (NO RE-DEBATIR)**:
 - **Total**: 65 columnas `DateTime`
-- **TIMESTAMP-AFFECTED** (`USING "col" AT TIME ZONE 'America/La_Paz'`): 48 columnas
-- **UTC-NOON** (`USING "col" AT TIME ZONE 'UTC'`): 17 columnas
+- **TIMESTAMP-AFFECTED** (`USING "col" AT TIME ZONE 'America/La_Paz'`): 49 columnas
+- **UTC-NOON** (`USING "col" AT TIME ZONE 'UTC'`): 16 columnas
 
 ---
 
@@ -186,9 +186,9 @@ pnpm prisma migrate dev --create-only --name timestamptz_migration
 
 ---
 
-### T-4: Editar el SQL — agregar `USING AT TIME ZONE 'America/La_Paz'` a las 48 columnas TIMESTAMP-AFFECTED
+### T-4: Editar el SQL — agregar `USING AT TIME ZONE 'America/La_Paz'` a las 49 columnas TIMESTAMP-AFFECTED
 
-**Qué hacer**: Abrir `prisma/migrations/*_timestamptz_migration/migration.sql` y reescribir cada `ALTER COLUMN` de las 48 columnas TIMESTAMP-AFFECTED para que tenga el formato correcto:
+**Qué hacer**: Abrir `prisma/migrations/*_timestamptz_migration/migration.sql` y reescribir cada `ALTER COLUMN` de las 49 columnas TIMESTAMP-AFFECTED para que tenga el formato correcto:
 
 ```sql
 ALTER TABLE "<table_name>"
@@ -196,7 +196,7 @@ ALTER TABLE "<table_name>"
   USING "<column_name>" AT TIME ZONE 'America/La_Paz';
 ```
 
-**Lista completa de las 48 columnas TIMESTAMP-AFFECTED** (tabla SQL → columna):
+**Lista completa de las 49 columnas TIMESTAMP-AFFECTED** (tabla SQL → columna):
 
 ```
 organizations            → createdAt
@@ -235,9 +235,9 @@ document_signature_configs → createdAt, updatedAt
 
 ---
 
-### T-5: Editar el SQL — agregar `USING AT TIME ZONE 'UTC'` a las 17 columnas UTC-NOON
+### T-5: Editar el SQL — agregar `USING AT TIME ZONE 'UTC'` a las 16 columnas UTC-NOON
 
-**Qué hacer**: En el mismo archivo `migration.sql`, reescribir cada `ALTER COLUMN` de las 17 columnas UTC-NOON:
+**Qué hacer**: En el mismo archivo `migration.sql`, reescribir cada `ALTER COLUMN` de las 16 columnas UTC-NOON:
 
 ```sql
 ALTER TABLE "<table_name>"
@@ -245,7 +245,7 @@ ALTER TABLE "<table_name>"
   USING "<column_name>" AT TIME ZONE 'UTC';
 ```
 
-**Lista completa de las 17 columnas UTC-NOON** (tabla SQL → columna):
+**Lista completa de las 16 columnas UTC-NOON** (tabla SQL → columna):
 
 ```
 chicken_lots          → startDate, endDate
@@ -277,7 +277,7 @@ iva_sales_books       → fechaFactura
 ```sql
 -- ============================================================
 -- TIMESTAMP-AFFECTED: datos naive BO-local → USING 'America/La_Paz'
--- (48 columnas — representan instantes reales en el tiempo)
+-- (49 columnas — representan instantes reales en el tiempo)
 -- ============================================================
 
 -- organizations
@@ -297,7 +297,7 @@ ALTER TABLE "custom_roles"
 
 -- ============================================================
 -- UTC-NOON: datos ya en UTC vía toNoonUtc() → USING 'UTC'
--- (17 columnas — representan fechas calendario como TIMESTAMPTZ)
+-- (16 columnas — representan fechas calendario como TIMESTAMPTZ)
 -- ============================================================
 
 -- chicken_lots
@@ -342,48 +342,57 @@ grep -c "ALTER COLUMN" prisma/migrations/*_timestamptz_migration/migration.sql
 
 ### T-8: Grep #2 — Ningún `ALTER COLUMN` sin cláusula `USING` (BLOQUEANTE)
 
-**Comando exacto**:
+> ⚠️ **DEFECTO CONOCIDO DEL COMANDO ORIGINAL** (descubierto en apply 2026-04-27): el comando "exacto" descrito abajo asume `TYPE TIMESTAMPTZ` y `USING` en la misma línea, pero el SQL editado por T-6 los pone en líneas separadas (formato multi-línea más legible). Como resultado, el método 1 reporta TODOS los ALTER como falsos positivos (= 65 cuando esperaba 0). **Usar el método 2 (awk multi-línea) como gate real**.
+
+**Comando original (DEFECTUOSO con SQL multi-línea — NO usar como gate)**:
 ```bash
 grep "TYPE TIMESTAMPTZ" prisma/migrations/*_timestamptz_migration/migration.sql | grep -v "USING"
+# DEFECTO: si TYPE y USING están en líneas separadas, este comando reporta TODOS los ALTER como falsos positivos.
 ```
 
-**Resultado esperado**: `0 líneas` (salida vacía — el comando no imprime nada)
+**Comando correcto (multi-línea — gate real)**:
+```bash
+awk '/TYPE TIMESTAMPTZ/{type_ln=NR; getline next_line; if (next_line !~ /USING/) print "FALTA USING después de línea", type_ln, ":", next_line}' \
+  prisma/migrations/*_timestamptz_migration/migration.sql
+```
 
-> **BLOQUEANTE** — Si este grep imprime cualquier línea, existe al menos un `ALTER COLUMN ... TYPE TIMESTAMPTZ` sin su cláusula `USING`. Esas líneas permiten el casting implícito de Postgres que asume UTC, lo cual corrompería los datos naive BO-local. NO ejecutar T-11. Agregar la cláusula `USING` correcta a cada línea reportada.
+**Resultado esperado**: `0 líneas` (salida vacía — el awk no imprime nada). El awk recorre el archivo, en cada `TYPE TIMESTAMPTZ` mira la línea siguiente, y solo imprime si NO contiene `USING`.
 
-**Criterio de completion**: el comando no produce output (salida vacía), exit code 1 es aceptable (grep devuelve 1 cuando no hay matches).
+> **BLOQUEANTE** — Si el awk imprime cualquier línea, existe al menos un `ALTER COLUMN ... TYPE TIMESTAMPTZ` sin su cláusula `USING` en la línea siguiente. Esas filas permitirían el casting implícito de Postgres que asume UTC, lo cual corrompería los datos naive BO-local. NO ejecutar T-11. Agregar la cláusula `USING` correcta a cada ALTER reportado.
+
+**Criterio de completion**: el awk no produce output (salida vacía).
 
 ---
 
-### T-9: Grep #3 — Count `USING 'America/La_Paz'` debe ser exactamente 48 (BLOQUEANTE)
+### T-9: Grep #3 — Count `USING 'America/La_Paz'` debe ser exactamente 49 (BLOQUEANTE)
 
 **Comando exacto**:
 ```bash
 grep -c "AT TIME ZONE 'America/La_Paz'" prisma/migrations/*_timestamptz_migration/migration.sql
 ```
 
-**Resultado esperado**: `48`
+**Resultado esperado**: `49`
 
-> **BLOQUEANTE** — Si este grep reporta cualquier número distinto de `48`, la distribución de cláusulas TIMESTAMP-AFFECTED está incorrecta. Puede significar que alguna columna TIMESTAMP-AFFECTED quedó con `USING 'UTC'` (error grave: corrompería datos) o viceversa. NO ejecutar T-11. Auditar las 48 columnas contra la lista canónica de T-4.
+> **BLOQUEANTE** — Si este grep reporta cualquier número distinto de `49`, la distribución de cláusulas TIMESTAMP-AFFECTED está incorrecta. Puede significar que alguna columna TIMESTAMP-AFFECTED quedó con `USING 'UTC'` (error grave: corrompería datos) o viceversa. NO ejecutar T-11. Auditar las 49 columnas contra la lista canónica de T-4.
 
-**Criterio de completion**: el comando imprime `48` y termina con exit code 0.
+**Criterio de completion**: el comando imprime `49` y termina con exit code 0.
 
 ---
 
-### T-10: Grep #4 — Count `USING 'UTC'` debe ser exactamente 17 (BLOQUEANTE)
+### T-10: Grep #4 — Count `USING 'UTC'` debe ser exactamente 16 (BLOQUEANTE)
 
 **Comando exacto**:
 ```bash
 grep -c "AT TIME ZONE 'UTC'" prisma/migrations/*_timestamptz_migration/migration.sql
 ```
 
-**Resultado esperado**: `17`
+**Resultado esperado**: `16`
 
-> **BLOQUEANTE** — Si este grep reporta cualquier número distinto de `17`, la distribución de cláusulas UTC-NOON está incorrecta. NO ejecutar T-11. Auditar las 17 columnas contra la lista canónica de T-5.
+> **BLOQUEANTE** — Si este grep reporta cualquier número distinto de `16`, la distribución de cláusulas UTC-NOON está incorrecta. NO ejecutar T-11. Auditar las 16 columnas contra la lista canónica de T-5.
 
-**Verificación cruzada adicional** (suma): los resultados de T-9 y T-10 deben sumar 65. Si `48 + 17 ≠ 65`, hay un error de conteo que debe resolverse antes de continuar.
+**Verificación cruzada adicional** (suma): los resultados de T-9 y T-10 deben sumar 65. Si `49 + 16 ≠ 65`, hay un error de conteo que debe resolverse antes de continuar.
 
-**Criterio de completion**: el comando imprime `17` y termina con exit code 0, y la suma con T-9 es 65.
+**Criterio de completion**: el comando imprime `16` y termina con exit code 0, y la suma con T-9 es 65.
 
 ---
 
@@ -392,8 +401,8 @@ grep -c "AT TIME ZONE 'UTC'" prisma/migrations/*_timestamptz_migration/migration
 > **PRE-CONDICIÓN BLOQUEANTE**: Fase 3 completada con los 4 greps reportando OK:
 > - T-7: `65`
 > - T-8: `0 líneas` (salida vacía)
-> - T-9: `48`
-> - T-10: `17`
+> - T-9: `49`
+> - T-10: `16`
 >
 > **Sin esta pre-condición, T-11 NO se ejecuta bajo ninguna circunstancia.**
 >
@@ -432,9 +441,9 @@ feat(db): migrate DateTime columns to TIMESTAMPTZ(3)
 Applies timestamptz_migration: 65 ALTER TABLE statements converting
 all DateTime columns from TIMESTAMP(3) to TIMESTAMPTZ(3).
 
-- 48 TIMESTAMP-AFFECTED columns use USING AT TIME ZONE 'America/La_Paz'
+- 49 TIMESTAMP-AFFECTED columns use USING AT TIME ZONE 'America/La_Paz'
   (naive BO-local data → correct UTC instant)
-- 17 UTC-NOON columns use USING AT TIME ZONE 'UTC'
+- 16 UTC-NOON columns use USING AT TIME ZONE 'UTC'
   (dates stored as UTC-noon via toNoonUtc() → preserved without shift)
 
 Fixes a -4h display bug caused by node-postgres misreading naive-local
@@ -911,7 +920,7 @@ T-1 → T-2 → [T-2 OK?] → T-3 → T-4 → T-5 → T-6
 |------|--------|------|
 | Fase 1 — Schema Prisma | T-1, T-2 | T-2: 0 líneas sin anotación, 65 anotadas |
 | Fase 2 — Generación SQL | T-3, T-4, T-5, T-6 | SQL editado con USING en todos los ALTER |
-| Fase 3 — Gate pre-apply | T-7, T-8, T-9, T-10 | **BLOQUEANTE**: 65 / 0 líneas / 48 / 17 |
+| Fase 3 — Gate pre-apply | T-7, T-8, T-9, T-10 | **BLOQUEANTE**: 65 / 0 líneas / 49 / 16 |
 | Fase 4 — Apply | T-11 | `pnpm prisma migrate dev` con exit code 0 |
 | Fase 5 — Tests TDD (RED) | T-12 | 3 tests nuevos fallan en RED (razón correcta) |
 | Fase 6 — Fix cursor | T-13 | Tests pasan en GREEN |

--- a/openspec/changes/timestamptz-migration/tasks.md
+++ b/openspec/changes/timestamptz-migration/tasks.md
@@ -226,7 +226,7 @@ audit_logs               → createdAt
 iva_purchase_books       → createdAt, updatedAt
 iva_sales_books          → createdAt, updatedAt
 org_profile              → createdAt, updatedAt
-document_signature_configs → createdAt, updatedAt
+document_signature_config → createdAt, updatedAt
 ```
 
 **Referencia de nombres de tabla**: ver tabla "Mapeo tabla SQL → modelo Prisma" en `design.md`.
@@ -787,7 +787,7 @@ WHERE data_type = 'timestamp with time zone'
     'accounts_receivable','accounts_payable','org_settings','dispatches',
     'product_types','payments','operational_doc_types','purchases',
     'purchase_details','sales','audit_logs','iva_purchase_books',
-    'iva_sales_books','org_profile','document_signature_configs'
+    'iva_sales_books','org_profile','document_signature_config'
   );
 -- Esperado: 65
 ```

--- a/prisma/migrations/20260427014214_timestamptz_migration/migration.sql
+++ b/prisma/migrations/20260427014214_timestamptz_migration/migration.sql
@@ -1,0 +1,288 @@
+-- ============================================================
+-- TIMESTAMP-AFFECTED: datos naive BO-local → USING 'America/La_Paz'
+-- (49 columnas — representan instantes reales en el tiempo)
+-- ============================================================
+
+-- accounts_payable
+ALTER TABLE "accounts_payable"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "accounts_payable"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- accounts_receivable
+ALTER TABLE "accounts_receivable"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "accounts_receivable"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- agent_rate_limits
+ALTER TABLE "agent_rate_limits"
+  ALTER COLUMN "windowStart" TYPE TIMESTAMPTZ(3)
+  USING "windowStart" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "agent_rate_limits"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- audit_logs
+ALTER TABLE "audit_logs"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+
+-- chat_messages
+ALTER TABLE "chat_messages"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+
+-- chicken_lots
+ALTER TABLE "chicken_lots"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "chicken_lots"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- contacts
+ALTER TABLE "contacts"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "contacts"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- custom_roles
+ALTER TABLE "custom_roles"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "custom_roles"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- dispatches
+ALTER TABLE "dispatches"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "dispatches"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- document_signature_config
+ALTER TABLE "document_signature_config"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "document_signature_config"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- documents
+ALTER TABLE "documents"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+
+-- expenses
+ALTER TABLE "expenses"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+
+-- farms
+ALTER TABLE "farms"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "farms"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- fiscal_periods
+ALTER TABLE "fiscal_periods"
+  ALTER COLUMN "closedAt" TYPE TIMESTAMPTZ(3)
+  USING "closedAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "fiscal_periods"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "fiscal_periods"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- iva_purchase_books
+ALTER TABLE "iva_purchase_books"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "iva_purchase_books"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- iva_sales_books
+ALTER TABLE "iva_sales_books"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "iva_sales_books"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- journal_entries
+ALTER TABLE "journal_entries"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "journal_entries"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- mortality_logs
+ALTER TABLE "mortality_logs"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+
+-- operational_doc_types
+ALTER TABLE "operational_doc_types"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "operational_doc_types"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- org_profile
+ALTER TABLE "org_profile"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "org_profile"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- org_settings
+ALTER TABLE "org_settings"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "org_settings"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- organization_members
+ALTER TABLE "organization_members"
+  ALTER COLUMN "deactivatedAt" TYPE TIMESTAMPTZ(3)
+  USING "deactivatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- organizations
+ALTER TABLE "organizations"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+
+-- payments
+ALTER TABLE "payments"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "payments"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- product_types
+ALTER TABLE "product_types"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "product_types"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- purchases
+ALTER TABLE "purchases"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "purchases"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- sales
+ALTER TABLE "sales"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+ALTER TABLE "sales"
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(3)
+  USING "updatedAt" AT TIME ZONE 'America/La_Paz';
+
+-- users
+ALTER TABLE "users"
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(3)
+  USING "createdAt" AT TIME ZONE 'America/La_Paz';
+
+-- ============================================================
+-- UTC-NOON: datos ya en UTC vía toNoonUtc() → USING 'UTC'
+-- (16 columnas — representan fechas calendario como TIMESTAMPTZ)
+-- ============================================================
+
+-- accounts_payable
+ALTER TABLE "accounts_payable"
+  ALTER COLUMN "dueDate" TYPE TIMESTAMPTZ(3)
+  USING "dueDate" AT TIME ZONE 'UTC';
+
+-- accounts_receivable
+ALTER TABLE "accounts_receivable"
+  ALTER COLUMN "dueDate" TYPE TIMESTAMPTZ(3)
+  USING "dueDate" AT TIME ZONE 'UTC';
+
+-- chicken_lots
+ALTER TABLE "chicken_lots"
+  ALTER COLUMN "startDate" TYPE TIMESTAMPTZ(3)
+  USING "startDate" AT TIME ZONE 'UTC';
+ALTER TABLE "chicken_lots"
+  ALTER COLUMN "endDate" TYPE TIMESTAMPTZ(3)
+  USING "endDate" AT TIME ZONE 'UTC';
+
+-- dispatches
+ALTER TABLE "dispatches"
+  ALTER COLUMN "date" TYPE TIMESTAMPTZ(3)
+  USING "date" AT TIME ZONE 'UTC';
+
+-- expenses
+ALTER TABLE "expenses"
+  ALTER COLUMN "date" TYPE TIMESTAMPTZ(3)
+  USING "date" AT TIME ZONE 'UTC';
+
+-- fiscal_periods
+ALTER TABLE "fiscal_periods"
+  ALTER COLUMN "startDate" TYPE TIMESTAMPTZ(3)
+  USING "startDate" AT TIME ZONE 'UTC';
+ALTER TABLE "fiscal_periods"
+  ALTER COLUMN "endDate" TYPE TIMESTAMPTZ(3)
+  USING "endDate" AT TIME ZONE 'UTC';
+
+-- iva_purchase_books
+ALTER TABLE "iva_purchase_books"
+  ALTER COLUMN "fechaFactura" TYPE TIMESTAMPTZ(3)
+  USING "fechaFactura" AT TIME ZONE 'UTC';
+
+-- iva_sales_books
+ALTER TABLE "iva_sales_books"
+  ALTER COLUMN "fechaFactura" TYPE TIMESTAMPTZ(3)
+  USING "fechaFactura" AT TIME ZONE 'UTC';
+
+-- journal_entries
+ALTER TABLE "journal_entries"
+  ALTER COLUMN "date" TYPE TIMESTAMPTZ(3)
+  USING "date" AT TIME ZONE 'UTC';
+
+-- mortality_logs
+ALTER TABLE "mortality_logs"
+  ALTER COLUMN "date" TYPE TIMESTAMPTZ(3)
+  USING "date" AT TIME ZONE 'UTC';
+
+-- payments
+ALTER TABLE "payments"
+  ALTER COLUMN "date" TYPE TIMESTAMPTZ(3)
+  USING "date" AT TIME ZONE 'UTC';
+
+-- purchase_details
+ALTER TABLE "purchase_details"
+  ALTER COLUMN "fecha" TYPE TIMESTAMPTZ(3)
+  USING "fecha" AT TIME ZONE 'UTC';
+
+-- purchases
+ALTER TABLE "purchases"
+  ALTER COLUMN "date" TYPE TIMESTAMPTZ(3)
+  USING "date" AT TIME ZONE 'UTC';
+
+-- sales
+ALTER TABLE "sales"
+  ALTER COLUMN "date" TYPE TIMESTAMPTZ(3)
+  USING "date" AT TIME ZONE 'UTC';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,7 +15,7 @@ model Organization {
   clerkOrgId  String   @unique
   name        String
   slug        String   @unique
-  createdAt   DateTime @default(now())
+  createdAt   DateTime @db.Timestamptz(3) @default(now())
   members        OrganizationMember[]
   documents      Document[]
   farms          Farm[]
@@ -57,8 +57,8 @@ model CustomRole {
   permissionsRead  String[]
   permissionsWrite String[]
   canPost          String[]
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
+  createdAt        DateTime @db.Timestamptz(3) @default(now())
+  updatedAt        DateTime @db.Timestamptz(3) @updatedAt
   organization     Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@unique([organizationId, slug])
@@ -71,7 +71,7 @@ model OrganizationMember {
   organizationId String
   userId         String
   role           String    @default("member")
-  deactivatedAt  DateTime?
+  deactivatedAt  DateTime? @db.Timestamptz(3)
   organization   Organization @relation(fields: [organizationId], references: [id])
   user           User         @relation(fields: [userId], references: [id])
   farms          Farm[]
@@ -86,7 +86,7 @@ model User {
   clerkUserId String   @unique
   email       String
   name        String?
-  createdAt   DateTime @default(now())
+  createdAt   DateTime @db.Timestamptz(3) @default(now())
   memberships    OrganizationMember[]
   documents      Document[]
   expenses       Expense[]       @relation("ExpenseCreator")
@@ -118,7 +118,7 @@ model Document {
   user           User         @relation(fields: [userId], references: [id])
   chunks         DocumentChunk[]
 
-  createdAt      DateTime @default(now())
+  createdAt      DateTime @db.Timestamptz(3) @default(now())
 
   @@index([organizationId])
   @@index([userId])
@@ -147,7 +147,7 @@ model ChatMessage {
   userId         String
   role           String
   content        String
-  createdAt      DateTime @default(now())
+  createdAt      DateTime @db.Timestamptz(3) @default(now())
 
   @@index([sessionId, createdAt])
   @@index([organizationId, userId])
@@ -163,9 +163,9 @@ model AgentRateLimit {
   id             String   @id @default(cuid())
   organizationId String
   userId         String
-  windowStart    DateTime
+  windowStart    DateTime @db.Timestamptz(3)
   count          Int      @default(0)
-  updatedAt      DateTime @updatedAt
+  updatedAt      DateTime @db.Timestamptz(3) @updatedAt
 
   @@unique([organizationId, userId, windowStart])
   @@index([windowStart])
@@ -197,8 +197,8 @@ model Farm {
   location       String?
   organizationId String
   memberId       String
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  createdAt      DateTime @db.Timestamptz(3) @default(now())
+  updatedAt      DateTime @db.Timestamptz(3) @updatedAt
   organization   Organization       @relation(fields: [organizationId], references: [id])
   member         OrganizationMember @relation(fields: [memberId], references: [id])
   lots           ChickenLot[]
@@ -213,13 +213,13 @@ model ChickenLot {
   name           String
   barnNumber     Int
   initialCount   Int
-  startDate      DateTime
-  endDate        DateTime?
+  startDate      DateTime @db.Timestamptz(3)
+  endDate        DateTime? @db.Timestamptz(3)
   status         LotStatus @default(ACTIVE)
   farmId         String
   organizationId String
-  createdAt      DateTime  @default(now())
-  updatedAt      DateTime  @updatedAt
+  createdAt      DateTime  @db.Timestamptz(3) @default(now())
+  updatedAt      DateTime  @db.Timestamptz(3) @updatedAt
   farm           Farm         @relation(fields: [farmId], references: [id])
   organization   Organization @relation(fields: [organizationId], references: [id])
   expenses       Expense[]
@@ -235,11 +235,11 @@ model Expense {
   amount         Decimal         @db.Decimal(12, 2)
   category       ExpenseCategory
   description    String?
-  date           DateTime
+  date           DateTime @db.Timestamptz(3)
   lotId          String
   organizationId String
   createdById    String
-  createdAt      DateTime        @default(now())
+  createdAt      DateTime        @db.Timestamptz(3) @default(now())
   lot            ChickenLot   @relation(fields: [lotId], references: [id])
   organization   Organization @relation(fields: [organizationId], references: [id])
   createdBy      User         @relation("ExpenseCreator", fields: [createdById], references: [id])
@@ -254,11 +254,11 @@ model MortalityLog {
   id             String   @id @default(cuid())
   count          Int
   cause          String?
-  date           DateTime
+  date           DateTime @db.Timestamptz(3)
   lotId          String
   organizationId String
   createdById    String
-  createdAt      DateTime @default(now())
+  createdAt      DateTime @db.Timestamptz(3) @default(now())
   lot            ChickenLot   @relation(fields: [lotId], references: [id])
   organization   Organization @relation(fields: [organizationId], references: [id])
   createdBy      User         @relation("MortalityCreator", fields: [createdById], references: [id])
@@ -359,7 +359,7 @@ model JournalEntry {
   id              String             @id @default(cuid())
   number          Int
   referenceNumber Int?               // optional physical document number
-  date            DateTime
+  date            DateTime           @db.Timestamptz(3)
   description     String
   status          JournalEntryStatus @default(DRAFT)
   periodId        String
@@ -371,8 +371,8 @@ model JournalEntry {
   organizationId  String
   createdById     String
   updatedById     String?
-  createdAt       DateTime           @default(now())
-  updatedAt       DateTime           @updatedAt
+  createdAt       DateTime           @db.Timestamptz(3) @default(now())
+  updatedAt       DateTime           @db.Timestamptz(3) @updatedAt
   organization    Organization       @relation(fields: [organizationId], references: [id])
   period          FiscalPeriod       @relation(fields: [periodId], references: [id])
   voucherType     VoucherTypeCfg     @relation(fields: [voucherTypeId], references: [id])
@@ -419,14 +419,14 @@ model FiscalPeriod {
   name           String
   year           Int
   month          Int                // 1..12 — calendar month (CHECK constraint in migration)
-  startDate      DateTime
-  endDate        DateTime
+  startDate      DateTime           @db.Timestamptz(3)
+  endDate        DateTime           @db.Timestamptz(3)
   status         FiscalPeriodStatus @default(OPEN)
-  closedAt       DateTime?
+  closedAt       DateTime?          @db.Timestamptz(3)
   closedBy       String?
   createdById    String
-  createdAt      DateTime           @default(now())
-  updatedAt      DateTime           @updatedAt
+  createdAt      DateTime           @db.Timestamptz(3) @default(now())
+  updatedAt      DateTime           @db.Timestamptz(3) @updatedAt
   organization   Organization       @relation(fields: [organizationId], references: [id])
   closedByUser   User?              @relation("FiscalPeriodCloser", fields: [closedBy], references: [id])
   journalEntries JournalEntry[]
@@ -575,8 +575,8 @@ model Contact {
   paymentTermsDays Int         @default(30)
   creditLimit      Decimal?    @db.Decimal(12, 2)
   isActive         Boolean     @default(true)
-  createdAt        DateTime    @default(now())
-  updatedAt        DateTime    @updatedAt
+  createdAt        DateTime    @db.Timestamptz(3) @default(now())
+  updatedAt        DateTime    @db.Timestamptz(3) @updatedAt
   organization     Organization         @relation(fields: [organizationId], references: [id])
   journalEntries   JournalEntry[]
   journalLines     JournalLine[]
@@ -601,14 +601,14 @@ model AccountsReceivable {
   amount         Decimal          @db.Decimal(12, 2)
   paid           Decimal          @default(0) @db.Decimal(12, 2)
   balance        Decimal          @db.Decimal(12, 2)
-  dueDate        DateTime
+  dueDate        DateTime         @db.Timestamptz(3)
   status         ReceivableStatus @default(PENDING)
   sourceType     String?
   sourceId       String?
   journalEntryId String?
   notes          String?
-  createdAt      DateTime         @default(now())
-  updatedAt      DateTime         @updatedAt
+  createdAt      DateTime         @db.Timestamptz(3) @default(now())
+  updatedAt      DateTime         @db.Timestamptz(3) @updatedAt
   organization   Organization  @relation(fields: [organizationId], references: [id])
   contact        Contact       @relation(fields: [contactId], references: [id])
   journalEntry   JournalEntry? @relation(fields: [journalEntryId], references: [id])
@@ -630,14 +630,14 @@ model AccountsPayable {
   amount         Decimal       @db.Decimal(12, 2)
   paid           Decimal       @default(0) @db.Decimal(12, 2)
   balance        Decimal       @db.Decimal(12, 2)
-  dueDate        DateTime
+  dueDate        DateTime      @db.Timestamptz(3)
   status         PayableStatus @default(PENDING)
   sourceType     String?
   sourceId       String?
   journalEntryId String?
   notes          String?
-  createdAt      DateTime      @default(now())
-  updatedAt      DateTime      @updatedAt
+  createdAt      DateTime      @db.Timestamptz(3) @default(now())
+  updatedAt      DateTime      @db.Timestamptz(3) @updatedAt
   organization   Organization  @relation(fields: [organizationId], references: [id])
   contact        Contact       @relation(fields: [contactId], references: [id])
   journalEntry   JournalEntry? @relation(fields: [journalEntryId], references: [id])
@@ -672,8 +672,8 @@ model OrgSettings {
   polloFaenadoCOGSAccountCode  String @default("5.1.1")
   itExpenseAccountCode         String @default("5.3.3")
   itPayableAccountCode         String @default("2.1.7")
-  createdAt              DateTime     @default(now())
-  updatedAt              DateTime     @updatedAt
+  createdAt              DateTime     @db.Timestamptz(3) @default(now())
+  updatedAt              DateTime     @db.Timestamptz(3) @updatedAt
   organization           Organization @relation(fields: [organizationId], references: [id])
 
   @@map("org_settings")
@@ -686,7 +686,7 @@ model Dispatch {
   status          DispatchStatus @default(DRAFT)
   sequenceNumber  Int
   referenceNumber Int?
-  date            DateTime
+  date            DateTime       @db.Timestamptz(3)
   contactId       String
   periodId        String
   description     String
@@ -704,8 +704,8 @@ model Dispatch {
   receivableId    String?        @unique
   notes           String?
   createdById     String
-  createdAt       DateTime       @default(now())
-  updatedAt       DateTime       @updatedAt
+  createdAt       DateTime       @db.Timestamptz(3) @default(now())
+  updatedAt       DateTime       @db.Timestamptz(3) @updatedAt
   organization    Organization         @relation(fields: [organizationId], references: [id])
   contact         Contact              @relation(fields: [contactId], references: [id])
   period          FiscalPeriod         @relation(fields: [periodId], references: [id])
@@ -751,8 +751,8 @@ model ProductType {
   code           String
   isActive       Boolean  @default(true)
   sortOrder      Int      @default(0)
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  createdAt      DateTime @db.Timestamptz(3) @default(now())
+  updatedAt      DateTime @db.Timestamptz(3) @updatedAt
   organization      Organization     @relation(fields: [organizationId], references: [id])
   dispatchDetails   DispatchDetail[]
   purchaseDetails   PurchaseDetail[]
@@ -767,7 +767,7 @@ model Payment {
   organizationId        String
   status                PaymentStatus @default(DRAFT)
   method                PaymentMethod
-  date                  DateTime
+  date                  DateTime      @db.Timestamptz(3)
   amount                Decimal       @db.Decimal(12, 2)
   description           String
   periodId              String
@@ -778,8 +778,8 @@ model Payment {
   accountCode           String?
   operationalDocTypeId  String?
   createdById           String
-  createdAt             DateTime      @default(now())
-  updatedAt             DateTime      @updatedAt
+  createdAt             DateTime      @db.Timestamptz(3) @default(now())
+  updatedAt             DateTime      @db.Timestamptz(3) @updatedAt
   organization          Organization         @relation(fields: [organizationId], references: [id])
   contact               Contact              @relation(fields: [contactId], references: [id])
   period                FiscalPeriod         @relation(fields: [periodId], references: [id])
@@ -801,8 +801,8 @@ model OperationalDocType {
   name           String
   direction      OperationalDocDirection
   isActive       Boolean                 @default(true)
-  createdAt      DateTime                @default(now())
-  updatedAt      DateTime                @updatedAt
+  createdAt      DateTime                @db.Timestamptz(3) @default(now())
+  updatedAt      DateTime                @db.Timestamptz(3) @updatedAt
 
   organization   Organization            @relation(fields: [organizationId], references: [id])
   payments       Payment[]
@@ -818,7 +818,7 @@ model Purchase {
   purchaseType    PurchaseType
   status          PurchaseStatus @default(DRAFT)
   sequenceNumber  Int
-  date            DateTime
+  date            DateTime       @db.Timestamptz(3)
   contactId       String
   periodId        String
   description     String
@@ -839,8 +839,8 @@ model Purchase {
   journalEntryId  String?        @unique
   payableId       String?        @unique
   createdById     String
-  createdAt       DateTime       @default(now())
-  updatedAt       DateTime       @updatedAt
+  createdAt       DateTime       @db.Timestamptz(3) @default(now())
+  updatedAt       DateTime       @db.Timestamptz(3) @updatedAt
   organization    Organization         @relation(fields: [organizationId], references: [id])
   contact         Contact              @relation(fields: [contactId], references: [id])
   period          FiscalPeriod         @relation(fields: [periodId], references: [id])
@@ -864,7 +864,7 @@ model PurchaseDetail {
   lineAmount       Decimal  @db.Decimal(12, 2)
   order            Int      @default(0)
   // FLETE columns
-  fecha            DateTime?
+  fecha            DateTime? @db.Timestamptz(3)
   docRef           String?
   chickenQty       Int?
   pricePerChicken  Decimal? @db.Decimal(12, 4)
@@ -912,7 +912,7 @@ model Sale {
   organizationId  String
   status          SaleStatus   @default(DRAFT)
   sequenceNumber  Int
-  date            DateTime
+  date            DateTime     @db.Timestamptz(3)
   contactId       String
   periodId        String
   description     String
@@ -922,8 +922,8 @@ model Sale {
   journalEntryId  String?      @unique
   receivableId    String?      @unique
   createdById     String
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  createdAt       DateTime     @db.Timestamptz(3) @default(now())
+  updatedAt       DateTime     @db.Timestamptz(3) @updatedAt
   organization    Organization         @relation(fields: [organizationId], references: [id])
   contact         Contact              @relation(fields: [contactId], references: [id])
   period          FiscalPeriod         @relation(fields: [periodId], references: [id])
@@ -967,7 +967,7 @@ model AuditLog {
   changedById     String?
   justification   String?
   correlationId   String?  // Groups all audit rows emitted by a single close/reopen operation
-  createdAt       DateTime @default(now())
+  createdAt       DateTime @db.Timestamptz(3) @default(now())
   organization    Organization @relation(fields: [organizationId], references: [id])
 
   @@index([organizationId, entityType, entityId])
@@ -985,7 +985,7 @@ model IvaPurchaseBook {
   organizationId           String
   fiscalPeriodId           String
   purchaseId               String?        @unique
-  fechaFactura             DateTime
+  fechaFactura             DateTime       @db.Timestamptz(3)
   nitProveedor             String
   razonSocial              String
   numeroFactura            String
@@ -1009,8 +1009,8 @@ model IvaPurchaseBook {
   tipoCompra               Int            @default(1)
   status                   IvaBookStatus  @default(ACTIVE)
   notes                    String?
-  createdAt                DateTime       @default(now())
-  updatedAt                DateTime       @updatedAt
+  createdAt                DateTime       @db.Timestamptz(3) @default(now())
+  updatedAt                DateTime       @db.Timestamptz(3) @updatedAt
   organization             Organization   @relation(fields: [organizationId], references: [id])
   fiscalPeriod             FiscalPeriod   @relation(fields: [fiscalPeriodId], references: [id])
   purchase                 Purchase?      @relation(fields: [purchaseId], references: [id], onDelete: SetNull)
@@ -1025,7 +1025,7 @@ model IvaSalesBook {
   organizationId           String
   fiscalPeriodId           String
   saleId                   String?             @unique
-  fechaFactura             DateTime
+  fechaFactura             DateTime            @db.Timestamptz(3)
   nitCliente               String
   razonSocial              String
   numeroFactura            String
@@ -1049,8 +1049,8 @@ model IvaSalesBook {
   estadoSIN                IvaSalesEstadoSIN
   status                   IvaBookStatus       @default(ACTIVE)
   notes                    String?
-  createdAt                DateTime            @default(now())
-  updatedAt                DateTime            @updatedAt
+  createdAt                DateTime            @db.Timestamptz(3) @default(now())
+  updatedAt                DateTime            @db.Timestamptz(3) @updatedAt
   organization             Organization        @relation(fields: [organizationId], references: [id])
   fiscalPeriod             FiscalPeriod        @relation(fields: [fiscalPeriodId], references: [id])
   sale                     Sale?               @relation(fields: [saleId], references: [id], onDelete: SetNull)
@@ -1094,8 +1094,8 @@ model OrgProfile {
   representanteLegal String   @default("")
   nroPatronal        String?
   logoUrl        String?
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  createdAt      DateTime @db.Timestamptz(3) @default(now())
+  updatedAt      DateTime @db.Timestamptz(3) @updatedAt
   organization   Organization @relation(fields: [organizationId], references: [id])
 
   @@map("org_profile")
@@ -1107,8 +1107,8 @@ model DocumentSignatureConfig {
   documentType    DocumentPrintType
   labels          SignatureLabel[]
   showReceiverRow Boolean           @default(false)
-  createdAt       DateTime          @default(now())
-  updatedAt       DateTime          @updatedAt
+  createdAt       DateTime          @db.Timestamptz(3) @default(now())
+  updatedAt       DateTime          @db.Timestamptz(3) @updatedAt
   organization    Organization      @relation(fields: [organizationId], references: [id])
 
   @@unique([organizationId, documentType])


### PR DESCRIPTION
## Summary

Migra las 65 columnas `DateTime` del schema Prisma a `TIMESTAMPTZ(3)` y resuelve un bug de display `-4h` en `/audit` cuya causa raíz resultó ser el adapter `@prisma/adapter-pg@7.7.0` ignorando información de timezone en ambas direcciones del wire — no las columnas TIMESTAMP ni el cursor del audit como se asumía inicialmente.

El SDD reveló durante apply que la migración a TIMESTAMPTZ era **condición necesaria pero no suficiente**. El fix definitivo del síntoma visible es una sola línea: `options: '-c timezone=UTC'` en la config del adapter (commit `6fe4eef`).

## Root cause (descubierto durante apply)

El adapter `@prisma/adapter-pg@7.7.0` descarta info de TZ en ambas direcciones:

- **Escritura** (`formatDateTime` en `dist/index.js:389-393`): manda `'YYYY-MM-DD HH:MM:SS'` naive sin `Z` ni `+00`. Postgres con `session_timezone='America/La_Paz'` lo interpretaba como BO-local → almacenaba `+4h` del instante UTC real.
- **Lectura** (`normalize_timestamptz` en `dist/index.js:310-312`): regex `/[+-]\d{2}(:\d{2})?$/` borra el offset real (`-04`) y lo reemplaza por `+00:00` incondicionalmente. `Date` producido era `4h` antes del instante real.

Las dos manifestaciones son la misma raíz. Forzar `session_timezone='UTC'` alinea la asunción implícita del adapter (UTC) con la realidad explícita de la sesión.

## Changes

3 fixes ortogonales aplicados como commits separados:

| Commit | Tipo | Cambio | Archivos |
|--------|------|--------|----------|
| `e9cec08` | feat | Annotate 65 DateTime con `@db.Timestamptz(3)` | `prisma/schema.prisma` |
| `8546b9d` | feat | Migración SQL: 65 ALTER COLUMN con USING categorizado (49 La_Paz + 16 UTC) | `prisma/migrations/20260427014214_timestamptz_migration/migration.sql` |
| **`6fe4eef`** | **fix** | **`options: '-c timezone=UTC'` en adapter Prisma** (root cause fix) | `lib/prisma.ts` |
| `6c862bc` | fix | Cursor `::timestamp` → `::timestamptz` en audit (ANSI cleanup defensivo) | `features/audit/audit.repository.ts` |

Plus 8 commits de documentación SDD (proposal, specs, design, tasks, learnings, correcciones).

## Migration impact

⚠️ **Datos pre-fix**: cualquier escritura desde código JS antes del commit `6fe4eef` está almacenada con `+4h` de shift. Después del fix, el adapter lee correctamente, pero esos datos viejos aparecen "adelantados" en display. La DB de desarrollo se reseteó con `prisma migrate reset` durante apply. **Producción no aplica** — la base solo tenía datos de ejemplo.

⚠️ **Triggers SQL `NOW()`**: NO afectados (server-side, no pasan por el adapter). `audit_logs.createdAt` se popula via trigger y siempre fue correcto en DB; el bug visible venía de la lectura via Prisma.

## Validation

`sdd-verify` final: **8 PASS / 3 WARNING / 0 CRITICAL**.

| Check | Resultado |
|-------|-----------|
| Schema (REQ-TZ.1 a REQ-TZ.5) | ✅ All PASS |
| REQ-TZ.6 nuevo (session UTC en adapter) | ✅ PASS |
| Gates SQL (T-7..T-10) | ✅ 65/0/49/16 |
| `tsc --noEmit` | ✅ exit 0 |
| `pnpm test` | ⚠️ 3242 passed / 4 failed / 2 skipped — los 4 fallos son **pre-existentes** (verificados en `b949039` antes del SDD), NO regresión |
| Smoke test `/audit` | ✅ Hora correcta post-reset confirmada visualmente |
| `SHOW TimeZone` en sesión Prisma | ✅ `UTC` |

**Tests A1-S7/S8/S9 no implementados** — decisión documentada: bajo session UTC los tests serían no-diferenciales. Ver nota en `openspec/changes/timestamptz-migration/specs/audit-module/spec.md` y commit body de `6c862bc`.

## Operational notes

### Excepción al procedimiento de pg_dump

Esta migración se aplicó **SIN** `pg_dump` previo porque la base de desarrollo solo contenía datos de ejemplo generados para testing — no había datos productivos en riesgo.

**ESTE CRITERIO NO APLICA A PRODUCCIÓN.**

Futuras migraciones que modifiquen tipos de columnas en tablas con datos productivos **REQUIEREN** backup previo con `pg_dump` antes de ejecutar `prisma migrate dev`. La atomicidad de PostgreSQL (rollback en caso de fallo) no reemplaza al backup — protege contra errores de ejecución, no contra errores de lógica en la cláusula `USING`.

### Riesgo de lock en producción (R-D2 del design)

`ALTER TABLE ... ALTER COLUMN TYPE` adquiere `ACCESS EXCLUSIVE` lock por tabla. Para tablas de alto volumen (ej. `audit_logs` con millones de filas), este approach de ALTER directo **no es adecuado para producción** sin una ventana de mantenimiento o estrategia de migración online (`pg_repack`, columna shadow). Documentar y evaluar antes de ejecutar en producción.

### Blast radius del fix del adapter

`options: '-c timezone=UTC'` afecta TODAS las conexiones del pool de la app — todos los modelos con `@updatedAt` (~30) y todas las escrituras desde código JS quedan corregidas simultáneamente. Sin tocar ningún feature code.

## Aprendizajes del cambio

1. **La causa raíz era el adapter Prisma, no el cursor ni la falta de TIMESTAMPTZ**. El bug raíz no era `::timestamp` ni columnas TIMESTAMP sin TZ. Era el adapter `@prisma/adapter-pg@7.7.0` que descarta info de zona en ambas direcciones (`formatDateTime` no incluye Z al escribir, `normalize_timestamptz` borra el offset al leer con un regex). La migración a TIMESTAMPTZ era condición necesaria pero no suficiente. El fix de una línea (`options: '-c timezone=UTC'`) corrige ambos bugs simultáneamente porque alinea el comportamiento implícito del adapter (asume UTC) con el comportamiento explícito de la sesión (forzada UTC). El cursor fix queda como cleanup ANSI-conforme, no como solución al síntoma visible.

2. **Specs de bugs timezone/paginación requieren verificación empírica**. Modelarlos "desde afuera" llevó a 2 errores (shift contractivo vs expansivo, cardinalidad de scenarios) que el gate TDD detectó pero costó re-trabajo. Recomendación para SDDs futuros con tags `timezone`/`pagination`/`cursor`: trazar el dato extremo a extremo (DB → driver → ORM → app → display) con queries y logs reales antes de redactar scenarios.

3. **El gate TDD detectó problemas en specs, no en código**. En 2 iteraciones consecutivas, sin el gate, los tests "pasarían" siendo no-diferenciales y la spec quedaría con descripción incorrecta del bug. Mantener el gate como invariante para fixes de bugs sutiles.

## Test plan

- [ ] Pull la rama y ejecutar `pnpm prisma migrate status` → debe reportar todas las migraciones aplicadas, incluida `20260427014214_timestamptz_migration`
- [ ] Ejecutar `pnpm tsx -e "import {prisma} from './lib/prisma'; (async () => { const r: any = await prisma.\$queryRawUnsafe('SHOW TimeZone'); console.log(r); await prisma.\$disconnect(); })();"` → debe imprimir `UTC`
- [ ] Generar una operación nueva en `/audit` (crear/modificar asiento, venta, etc.) → la card debe mostrar la hora real de la operación en `America/La_Paz`
- [ ] `pnpm tsc --noEmit` → exit 0
- [ ] `pnpm test` → 3242+ passed (los 4 fallos pre-existentes son separados del cambio)
- [ ] Verificar que no hay datos pre-fix sin reset (si los hay, aparecen `+4h adelantados` en display)

## Referencias

- SDD artifacts completos: `openspec/changes/timestamptz-migration/`
- Spec persistence-timezone (capacidad nueva, REQ-TZ.1 a REQ-TZ.6)
- Spec audit-module (REQ-AUDIT.1 modificado, A1-S7 consolidado en A1-S8)
- Learnings detallados: `openspec/changes/timestamptz-migration/learnings.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)