### PR TITLE
feat(api): backend listo para la app móvil — Bearer auth + CORS + dispatch idempotente

### DIFF
--- a/modules/dispatch/__tests__/c0-domain-shape.poc-dispatch-hex.test.ts
+++ b/modules/dispatch/__tests__/c0-domain-shape.poc-dispatch-hex.test.ts
@@ -279,6 +279,7 @@ describe("POC dispatch-hex C0 — domain layer shape", () => {
         totalShrinkKg: null,
         totalShortageKg: null,
         totalRealNetKg: null,
+        clientId: null,
       });
       expect(dispatch.id).toBe("d-1");
       expect(dispatch.status).toBe("POSTED");
@@ -357,6 +358,7 @@ describe("POC dispatch-hex C0 — domain layer shape", () => {
           totalShrinkKg: null,
           totalShortageKg: null,
           totalRealNetKg: null,
+        clientId: null,
         });
         expect(() => posted.post()).toThrow(InvalidDispatchStatusTransition);
       });
@@ -392,6 +394,7 @@ describe("POC dispatch-hex C0 — domain layer shape", () => {
           totalShrinkKg: null,
           totalShortageKg: null,
           totalRealNetKg: null,
+        clientId: null,
         });
         const voided = posted.void();
         expect(voided.status).toBe("VOIDED");
@@ -428,6 +431,7 @@ describe("POC dispatch-hex C0 — domain layer shape", () => {
           totalShrinkKg: null,
           totalShortageKg: null,
           totalRealNetKg: null,
+        clientId: null,
         });
         const locked = posted.lock();
         expect(locked.status).toBe("LOCKED");
@@ -464,6 +468,7 @@ describe("POC dispatch-hex C0 — domain layer shape", () => {
           totalShrinkKg: null,
           totalShortageKg: null,
           totalRealNetKg: null,
+        clientId: null,
         });
         expect(() => voided.post()).toThrow(DispatchVoidedImmutable);
         expect(() => voided.void()).toThrow(DispatchVoidedImmutable);
@@ -515,6 +520,7 @@ describe("POC dispatch-hex C0 — domain layer shape", () => {
         totalShrinkKg: null,
         totalShortageKg: null,
         totalRealNetKg: null,
+        clientId: null,
       });
       expect(() => posted.assertCanDelete()).toThrow(DispatchNotDraft);
     });

--- a/modules/dispatch/__tests__/c1-application-shape.poc-dispatch-hex.test.ts
+++ b/modules/dispatch/__tests__/c1-application-shape.poc-dispatch-hex.test.ts
@@ -63,6 +63,7 @@ function makeInMemoryRepo(): DispatchRepository {
     linkJournalAndReceivableTx: async () => {},
     updateStatusTx: async (_o, _i, _s, _t, _sq) => null as never,
     cloneToDraftTx: async (_o, s) => s,
+    findByClientId: async () => null,
   };
 }
 
@@ -106,6 +107,13 @@ function makeInMemoryContacts(): DispatchContactsPort {
 function makeInMemoryPeriods(): DispatchFiscalPeriodsPort {
   return {
     getById: async () => ({
+      id: "p-1",
+      name: "2026-01",
+      status: "OPEN",
+      startDate: new Date("2000-01-01T00:00:00.000Z"),
+      endDate: new Date("2099-12-31T23:59:59.999Z"),
+    }),
+    findByDate: async () => ({
       id: "p-1",
       name: "2026-01",
       status: "OPEN",

--- a/modules/dispatch/application/__tests__/dispatch-service-mobile-contract.test.ts
+++ b/modules/dispatch/application/__tests__/dispatch-service-mobile-contract.test.ts
@@ -1,0 +1,343 @@
+/**
+ * TDD RED → GREEN — mobile offline contract tests for DispatchService.
+ *
+ * Change B: periodId optional — service resolves via findByDate when missing.
+ * Change C: clientId idempotency — service deduplicates via findByClientId.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DispatchService,
+  type DispatchServiceDeps,
+  type CreateDispatchInput,
+} from "../dispatch.service";
+import { DispatchPeriodNotFoundForDate } from "../../domain/errors/dispatch-errors";
+import type { DispatchRepository } from "../../domain/ports/dispatch.repository";
+import type { DispatchJournalEntryFactoryPort } from "../../domain/ports/dispatch-journal-entry-factory.port";
+import type { DispatchAccountBalancesPort } from "../../domain/ports/dispatch-account-balances.port";
+import type { DispatchOrgSettingsReaderPort } from "../../domain/ports/dispatch-org-settings-reader.port";
+import type { DispatchContactsPort } from "../../domain/ports/dispatch-contacts.port";
+import type { DispatchFiscalPeriodsPort } from "../../domain/ports/dispatch-fiscal-periods.port";
+import type { DispatchReceivablesPort } from "../../domain/ports/dispatch-receivables.port";
+import { Dispatch } from "../../domain/dispatch.entity";
+
+const ORG = "org-1";
+const CLIENT_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+// ── Base period fixture ────────────────────────────────────────────────────
+
+const OPEN_PERIOD = {
+  id: "p-1",
+  name: "2026-05",
+  status: "OPEN",
+  startDate: new Date("2026-05-01T00:00:00.000Z"),
+  endDate: new Date("2026-05-31T23:59:59.999Z"),
+};
+
+// ── Minimal dispatch fixture (fromPersistence) ─────────────────────────────
+
+function makePersistedDispatch(id = "d-existing"): Dispatch {
+  const now = new Date();
+  return Dispatch.fromPersistence({
+    id,
+    organizationId: ORG,
+    dispatchType: "NOTA_DESPACHO",
+    status: "DRAFT",
+    sequenceNumber: 0,
+    date: new Date("2026-05-19"),
+    contactId: "c-1",
+    periodId: "p-1",
+    description: "Despacho existente",
+    referenceNumber: null,
+    notes: null,
+    totalAmount: 0,
+    journalEntryId: null,
+    receivableId: null,
+    createdById: "user-1",
+    createdAt: now,
+    updatedAt: now,
+    details: [],
+    receivable: null,
+    farmOrigin: null,
+    chickenCount: null,
+    shrinkagePct: null,
+    avgKgPerChicken: null,
+    totalGrossKg: null,
+    totalNetKg: null,
+    totalShrinkKg: null,
+    totalShortageKg: null,
+    totalRealNetKg: null,
+    clientId: CLIENT_ID,
+  });
+}
+
+// ── Fake builders ──────────────────────────────────────────────────────────
+
+function makeRepo(overrides: Partial<DispatchRepository> = {}): DispatchRepository {
+  return {
+    findById: async () => null,
+    findAll: async () => [],
+    findPaginated: async () => ({
+      items: [],
+      total: 0,
+      page: 1,
+      pageSize: 25,
+      totalPages: 1,
+    }),
+    findByIdTx: async () => null,
+    saveTx: async (d) => d,
+    updateTx: async (d) => d,
+    deleteTx: async () => {},
+    getNextSequenceNumberTx: async () => 1,
+    linkJournalAndReceivableTx: async () => {},
+    updateStatusTx: async () => null as never,
+    cloneToDraftTx: async (_o, s) => s,
+    findByClientId: async () => null,
+    ...overrides,
+  };
+}
+
+function makeFactory(): DispatchJournalEntryFactoryPort {
+  return {
+    generateForDispatch: async () => "journal-1",
+    regenerateForDispatchEdit: async () => ({
+      oldJournalId: "j-old",
+      newJournalId: "j-new",
+    }),
+  };
+}
+
+function makeBalances(): DispatchAccountBalancesPort {
+  return {
+    applyPost: async () => {},
+    applyVoid: async () => {},
+  };
+}
+
+function makeOrgSettings(): DispatchOrgSettingsReaderPort {
+  return {
+    getOrCreate: async () => ({
+      roundingThreshold: 0.7,
+      cxcAccountCode: "1.1.3",
+    }),
+  };
+}
+
+function makeContacts(): DispatchContactsPort {
+  return {
+    getActiveById: async () => ({
+      id: "c-1",
+      name: "Cliente Test",
+      type: "CLIENTE",
+      paymentTermsDays: 30,
+    }),
+  };
+}
+
+function makePeriods(overrides: Partial<DispatchFiscalPeriodsPort> = {}): DispatchFiscalPeriodsPort {
+  return {
+    getById: async () => OPEN_PERIOD,
+    findByDate: async () => OPEN_PERIOD,
+    ...overrides,
+  };
+}
+
+function makeReceivables(): DispatchReceivablesPort {
+  return {
+    createTx: async () => "recv-1",
+    voidTx: async () => {},
+  };
+}
+
+function makeDeps(
+  overrides: Partial<DispatchServiceDeps> = {},
+): DispatchServiceDeps {
+  return {
+    repo: makeRepo(),
+    journalEntryFactory: makeFactory(),
+    accountBalances: makeBalances(),
+    orgSettings: makeOrgSettings(),
+    contacts: makeContacts(),
+    fiscalPeriods: makePeriods(),
+    receivables: makeReceivables(),
+    ...overrides,
+  };
+}
+
+function buildInput(
+  overrides: Partial<CreateDispatchInput> = {},
+): CreateDispatchInput {
+  return {
+    dispatchType: "NOTA_DESPACHO",
+    date: new Date("2026-05-19"),
+    contactId: "c-1",
+    description: "Despacho test",
+    createdById: "user-1",
+    details: [
+      {
+        description: "L1",
+        boxes: 1,
+        grossWeight: 10,
+        unitPrice: 50,
+        order: 0,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+// ── Change B: periodId resolution ──────────────────────────────────────────
+
+describe("DispatchService.create — periodId optional (change B)", () => {
+  it("resolves period via findByDate when periodId is absent", async () => {
+    const findByDate = vi.fn(async () => OPEN_PERIOD);
+    const service = new DispatchService(
+      makeDeps({
+        fiscalPeriods: makePeriods({ findByDate }),
+      }),
+    );
+
+    const dispatch = await service.create(ORG, buildInput({ periodId: undefined }));
+    expect(findByDate).toHaveBeenCalledWith(ORG, expect.any(Date));
+    expect(dispatch.periodId).toBe("p-1");
+  });
+
+  it("uses periodId directly when provided (web retrocompatible)", async () => {
+    const findByDate = vi.fn(async () => OPEN_PERIOD);
+    const getById = vi.fn(async () => OPEN_PERIOD);
+    const service = new DispatchService(
+      makeDeps({
+        fiscalPeriods: makePeriods({ findByDate, getById }),
+      }),
+    );
+
+    const dispatch = await service.create(ORG, buildInput({ periodId: "p-1" }));
+    expect(findByDate).not.toHaveBeenCalled();
+    expect(getById).toHaveBeenCalledWith(ORG, "p-1");
+    expect(dispatch.periodId).toBe("p-1");
+  });
+
+  it("throws when no period found for the date", async () => {
+    const service = new DispatchService(
+      makeDeps({
+        fiscalPeriods: makePeriods({ findByDate: async () => null }),
+      }),
+    );
+
+    await expect(
+      service.create(ORG, buildInput({ periodId: undefined })),
+    ).rejects.toThrow(DispatchPeriodNotFoundForDate);
+  });
+});
+
+// ── Change B: createAndPost — periodId resolution ──────────────────────────
+
+describe("DispatchService.createAndPost — periodId optional (change B)", () => {
+  it("resolves period via findByDate when periodId is absent", async () => {
+    const findByDate = vi.fn(async () => OPEN_PERIOD);
+    const service = new DispatchService(
+      makeDeps({
+        fiscalPeriods: makePeriods({ findByDate }),
+      }),
+    );
+
+    const { dispatch } = await service.createAndPost(
+      ORG,
+      buildInput({ periodId: undefined }),
+      "user-1",
+    );
+    expect(findByDate).toHaveBeenCalledWith(ORG, expect.any(Date));
+    expect(dispatch.periodId).toBe("p-1");
+  });
+
+  it("throws when no period found for the date", async () => {
+    const service = new DispatchService(
+      makeDeps({
+        fiscalPeriods: makePeriods({ findByDate: async () => null }),
+      }),
+    );
+
+    await expect(
+      service.createAndPost(ORG, buildInput({ periodId: undefined }), "user-1"),
+    ).rejects.toThrow(DispatchPeriodNotFoundForDate);
+  });
+});
+
+// ── Change C: clientId idempotency ─────────────────────────────────────────
+
+describe("DispatchService.create — clientId idempotency (change C)", () => {
+  it("returns existing dispatch without creating when clientId already exists", async () => {
+    const existing = makePersistedDispatch("d-existing");
+    const saveTx = vi.fn(async (d: Dispatch) => d);
+    const service = new DispatchService(
+      makeDeps({
+        repo: makeRepo({
+          findByClientId: async () => existing,
+          saveTx,
+        }),
+      }),
+    );
+
+    const result = await service.create(
+      ORG,
+      buildInput({ clientId: CLIENT_ID }),
+    );
+
+    expect(result.id).toBe("d-existing");
+    expect(saveTx).not.toHaveBeenCalled();
+  });
+
+  it("creates new dispatch when clientId not found (first call)", async () => {
+    const saveTx = vi.fn(async (d: Dispatch) => d);
+    const service = new DispatchService(
+      makeDeps({
+        repo: makeRepo({
+          findByClientId: async () => null,
+          saveTx,
+        }),
+      }),
+    );
+
+    await service.create(ORG, buildInput({ clientId: CLIENT_ID }));
+    expect(saveTx).toHaveBeenCalledOnce();
+  });
+
+  it("creates normally without clientId (web, no idempotency check)", async () => {
+    const findByClientId = vi.fn(async () => null);
+    const saveTx = vi.fn(async (d: Dispatch) => d);
+    const service = new DispatchService(
+      makeDeps({
+        repo: makeRepo({ findByClientId, saveTx }),
+      }),
+    );
+
+    await service.create(ORG, buildInput());
+    expect(findByClientId).not.toHaveBeenCalled();
+    expect(saveTx).toHaveBeenCalledOnce();
+  });
+
+  it("handles unique constraint race condition by returning existing dispatch", async () => {
+    // Simulates: findByClientId returns null (race), then saveTx throws P2002
+    const existing = makePersistedDispatch("d-race-winner");
+    const saveTx = vi.fn().mockRejectedValueOnce(
+      Object.assign(new Error("Unique constraint failed"), { code: "P2002" }),
+    );
+    const findByClientId = vi
+      .fn()
+      .mockResolvedValueOnce(null) // first check: not found
+      .mockResolvedValueOnce(existing); // recovery: found after race
+
+    const service = new DispatchService(
+      makeDeps({
+        repo: makeRepo({ findByClientId, saveTx }),
+      }),
+    );
+
+    const result = await service.create(
+      ORG,
+      buildInput({ clientId: CLIENT_ID }),
+    );
+
+    expect(result.id).toBe("d-race-winner");
+    expect(saveTx).toHaveBeenCalledOnce();
+  });
+});

--- a/modules/dispatch/application/__tests__/dispatch-service-source-type-code.test.ts
+++ b/modules/dispatch/application/__tests__/dispatch-service-source-type-code.test.ts
@@ -50,6 +50,7 @@ function makeRepo(): DispatchRepository {
     linkJournalAndReceivableTx: async () => {},
     updateStatusTx: async (_o, _i, _s, _t, _sq) => null as never,
     cloneToDraftTx: async (_o, s) => s,
+    findByClientId: async () => null,
   };
 }
 
@@ -93,6 +94,13 @@ function makeContacts(): DispatchContactsPort {
 function makePeriods(): DispatchFiscalPeriodsPort {
   return {
     getById: async () => ({
+      id: "p-1",
+      name: "2026-01",
+      status: "OPEN",
+      startDate: new Date("2000-01-01T00:00:00.000Z"),
+      endDate: new Date("2099-12-31T23:59:59.999Z"),
+    }),
+    findByDate: async () => ({
       id: "p-1",
       name: "2026-01",
       status: "OPEN",

--- a/modules/dispatch/application/dispatch.service.ts
+++ b/modules/dispatch/application/dispatch.service.ts
@@ -10,6 +10,7 @@ import {
   DispatchDateOutsidePeriod,
   DispatchNoDetails,
   DispatchNotDraft,
+  DispatchPeriodNotFoundForDate,
 } from "../domain/errors/dispatch-errors";
 import { isDateWithinPeriod } from "@/modules/fiscal-periods/domain/date-period-check";
 import {
@@ -75,7 +76,9 @@ export interface CreateDispatchInput {
   dispatchType: DispatchType;
   date: Date;
   contactId: string;
-  periodId: string;
+  // Optional: when absent the service resolves the period via findByDate.
+  // Web always sends it; mobile offline omits it.
+  periodId?: string;
   description: string;
   referenceNumber?: number;
   notes?: string;
@@ -83,6 +86,8 @@ export interface CreateDispatchInput {
   farmOrigin?: string;
   chickenCount?: number;
   shrinkagePct?: number;
+  // Mobile offline idempotency key — omit when creating from web.
+  clientId?: string;
   details: DetailLineInput[];
 }
 
@@ -140,6 +145,15 @@ export class DispatchService {
     organizationId: string,
     input: CreateDispatchInput,
   ): Promise<Dispatch> {
+    // Change C — idempotency: check for existing dispatch by clientId first.
+    if (input.clientId !== undefined) {
+      const existing = await this.deps.repo.findByClientId(
+        organizationId,
+        input.clientId,
+      );
+      if (existing) return existing;
+    }
+
     // Validate contact is CLIENTE
     const contact = await this.deps.contacts.getActiveById(
       organizationId,
@@ -152,10 +166,25 @@ export class DispatchService {
       );
     }
 
+    // Change B — resolve periodId when absent (mobile offline).
+    let resolvedPeriodId: string;
+    if (input.periodId !== undefined) {
+      resolvedPeriodId = input.periodId;
+    } else {
+      const periodByDate = await this.deps.fiscalPeriods.findByDate(
+        organizationId,
+        input.date,
+      );
+      if (!periodByDate) {
+        throw new DispatchPeriodNotFoundForDate(input.date);
+      }
+      resolvedPeriodId = periodByDate.id;
+    }
+
     // I12 — defense in depth: date∈período (NO valida status para preservar DRAFT en CLOSED).
     const periodForI12 = await this.deps.fiscalPeriods.getById(
       organizationId,
-      input.periodId,
+      resolvedPeriodId,
     );
     if (!isDateWithinPeriod(input.date, periodForI12)) {
       throw new DispatchDateOutsidePeriod(input.date, periodForI12.name);
@@ -188,7 +217,7 @@ export class DispatchService {
       organizationId,
       dispatchType: input.dispatchType,
       contactId: input.contactId,
-      periodId: input.periodId,
+      periodId: resolvedPeriodId,
       date: input.date,
       description: input.description,
       createdById: input.createdById,
@@ -197,6 +226,7 @@ export class DispatchService {
       farmOrigin: input.farmOrigin,
       chickenCount: input.chickenCount,
       shrinkagePct: input.shrinkagePct,
+      clientId: input.clientId,
       details: computedDetails.map((d) => ({
         description: d.description,
         boxes: d.boxes,
@@ -223,6 +253,28 @@ export class DispatchService {
     ) {
       const bcSummary = computeBcSummary(computedDetails, input.chickenCount);
       dispatch = dispatch.setBcSummary(bcSummary);
+    }
+
+    // Change C — race-safe idempotency: if the insert fails with a unique
+    // constraint violation on (organizationId, clientId), recover the winner.
+    if (input.clientId !== undefined) {
+      try {
+        return await this.deps.repo.saveTx(dispatch);
+      } catch (err) {
+        if (
+          typeof err === "object" &&
+          err !== null &&
+          "code" in err &&
+          (err as { code: unknown }).code === "P2002"
+        ) {
+          const recovered = await this.deps.repo.findByClientId(
+            organizationId,
+            input.clientId,
+          );
+          if (recovered) return recovered;
+        }
+        throw err;
+      }
     }
 
     return this.deps.repo.saveTx(dispatch);
@@ -258,10 +310,25 @@ export class DispatchService {
       }
     }
 
+    // Change B — resolve periodId when absent (mobile offline).
+    let resolvedPeriodId: string;
+    if (input.periodId !== undefined) {
+      resolvedPeriodId = input.periodId;
+    } else {
+      const periodByDate = await this.deps.fiscalPeriods.findByDate(
+        organizationId,
+        input.date,
+      );
+      if (!periodByDate) {
+        throw new DispatchPeriodNotFoundForDate(input.date);
+      }
+      resolvedPeriodId = periodByDate.id;
+    }
+
     // Validate period open
     const period = await this.deps.fiscalPeriods.getById(
       organizationId,
-      input.periodId,
+      resolvedPeriodId,
     );
     if (period.status !== "OPEN") {
       throw new ValidationError(
@@ -269,7 +336,7 @@ export class DispatchService {
         "PERIOD_CLOSED",
       );
     }
-    // I12 — date∈período (createAndPost: nace con input.date + input.periodId).
+    // I12 — date∈período (createAndPost: nace con input.date + resolvedPeriodId).
     if (!isDateWithinPeriod(input.date, period)) {
       throw new DispatchDateOutsidePeriod(input.date, period.name);
     }
@@ -321,7 +388,7 @@ export class DispatchService {
       organizationId,
       dispatchType: input.dispatchType,
       contactId: input.contactId,
-      periodId: input.periodId,
+      periodId: resolvedPeriodId,
       date: input.date,
       description: input.description,
       createdById: userId,
@@ -366,7 +433,7 @@ export class DispatchService {
       organizationId,
       contactId: input.contactId,
       date: input.date,
-      periodId: input.periodId,
+      periodId: resolvedPeriodId,
       description: journalDescription,
       sourceType: "dispatch",
       sourceId: dispatch.id,

--- a/modules/dispatch/domain/__tests__/dispatch-entity-client-id.test.ts
+++ b/modules/dispatch/domain/__tests__/dispatch-entity-client-id.test.ts
@@ -1,0 +1,124 @@
+/**
+ * TDD RED → GREEN — Change C: Dispatch entity accepts and exposes clientId.
+ */
+import { describe, it, expect } from "vitest";
+import { Dispatch } from "../dispatch.entity";
+
+describe("Dispatch entity — clientId (change C)", () => {
+  it("createDraft stores clientId when provided", () => {
+    const dispatch = Dispatch.createDraft({
+      organizationId: "org-1",
+      dispatchType: "NOTA_DESPACHO",
+      contactId: "c-1",
+      periodId: "p-1",
+      date: new Date("2026-05-19"),
+      description: "Despacho test",
+      createdById: "user-1",
+      clientId: "550e8400-e29b-41d4-a716-446655440000",
+      details: [],
+    });
+    expect(dispatch.clientId).toBe("550e8400-e29b-41d4-a716-446655440000");
+  });
+
+  it("createDraft stores null when clientId is omitted", () => {
+    const dispatch = Dispatch.createDraft({
+      organizationId: "org-1",
+      dispatchType: "NOTA_DESPACHO",
+      contactId: "c-1",
+      periodId: "p-1",
+      date: new Date("2026-05-19"),
+      description: "Despacho test",
+      createdById: "user-1",
+      details: [],
+    });
+    expect(dispatch.clientId).toBeNull();
+  });
+
+  it("fromPersistence maps clientId correctly", () => {
+    const now = new Date();
+    const dispatch = Dispatch.fromPersistence({
+      id: "d-1",
+      organizationId: "org-1",
+      dispatchType: "NOTA_DESPACHO",
+      status: "DRAFT",
+      sequenceNumber: 0,
+      date: now,
+      contactId: "c-1",
+      periodId: "p-1",
+      description: "Test",
+      referenceNumber: null,
+      notes: null,
+      totalAmount: 0,
+      journalEntryId: null,
+      receivableId: null,
+      createdById: "u-1",
+      createdAt: now,
+      updatedAt: now,
+      details: [],
+      receivable: null,
+      farmOrigin: null,
+      chickenCount: null,
+      shrinkagePct: null,
+      avgKgPerChicken: null,
+      totalGrossKg: null,
+      totalNetKg: null,
+      totalShrinkKg: null,
+      totalShortageKg: null,
+      totalRealNetKg: null,
+      clientId: "mobile-uuid-123",
+    });
+    expect(dispatch.clientId).toBe("mobile-uuid-123");
+  });
+
+  it("fromPersistence maps clientId as null when not set", () => {
+    const now = new Date();
+    const dispatch = Dispatch.fromPersistence({
+      id: "d-1",
+      organizationId: "org-1",
+      dispatchType: "NOTA_DESPACHO",
+      status: "DRAFT",
+      sequenceNumber: 0,
+      date: now,
+      contactId: "c-1",
+      periodId: "p-1",
+      description: "Test",
+      referenceNumber: null,
+      notes: null,
+      totalAmount: 0,
+      journalEntryId: null,
+      receivableId: null,
+      createdById: "u-1",
+      createdAt: now,
+      updatedAt: now,
+      details: [],
+      receivable: null,
+      farmOrigin: null,
+      chickenCount: null,
+      shrinkagePct: null,
+      avgKgPerChicken: null,
+      totalGrossKg: null,
+      totalNetKg: null,
+      totalShrinkKg: null,
+      totalShortageKg: null,
+      totalRealNetKg: null,
+      clientId: null,
+    });
+    expect(dispatch.clientId).toBeNull();
+  });
+
+  it("toSnapshot includes clientId", () => {
+    const dispatch = Dispatch.createDraft({
+      organizationId: "org-1",
+      dispatchType: "NOTA_DESPACHO",
+      contactId: "c-1",
+      periodId: "p-1",
+      date: new Date("2026-05-19"),
+      description: "Test",
+      createdById: "user-1",
+      clientId: "snap-client-id",
+      details: [],
+    });
+    const snap = dispatch.toSnapshot();
+    expect(snap.clientId).toBe("snap-client-id");
+  });
+});

--- a/modules/dispatch/domain/dispatch.entity.ts
+++ b/modules/dispatch/domain/dispatch.entity.ts
@@ -49,6 +49,8 @@ export interface DispatchProps {
   totalShrinkKg: number | null;
   totalShortageKg: number | null;
   totalRealNetKg: number | null;
+  // Mobile offline idempotency key — null when created from web
+  clientId: string | null;
 }
 
 export interface CreateDispatchDraftInput {
@@ -64,6 +66,8 @@ export interface CreateDispatchDraftInput {
   farmOrigin?: string;
   chickenCount?: number;
   shrinkagePct?: number;
+  // Mobile offline idempotency key — omit when creating from web
+  clientId?: string;
   details: Omit<import("./dispatch-detail.entity").CreateDispatchDetailInput, "dispatchId">[];
 }
 
@@ -107,6 +111,7 @@ export interface DispatchSnapshot {
   totalShrinkKg: number | null;
   totalShortageKg: number | null;
   totalRealNetKg: number | null;
+  clientId: string | null;
 }
 
 export class Dispatch {
@@ -162,6 +167,7 @@ export class Dispatch {
       totalShrinkKg: null,
       totalShortageKg: null,
       totalRealNetKg: null,
+      clientId: input.clientId ?? null,
     });
   }
 
@@ -291,6 +297,9 @@ export class Dispatch {
   get totalRealNetKg(): number | null {
     return this.props.totalRealNetKg;
   }
+  get clientId(): string | null {
+    return this.props.clientId;
+  }
 
   // ── State Machine ────────────────────────────────────────────────────────
 
@@ -411,6 +420,7 @@ export class Dispatch {
       totalShrinkKg: this.props.totalShrinkKg,
       totalShortageKg: this.props.totalShortageKg,
       totalRealNetKg: this.props.totalRealNetKg,
+      clientId: this.props.clientId,
     };
   }
 }

--- a/modules/dispatch/domain/errors/dispatch-errors.ts
+++ b/modules/dispatch/domain/errors/dispatch-errors.ts
@@ -113,3 +113,15 @@ export class DispatchDateOutsidePeriod extends ValidationError {
     this.name = "DispatchDateOutsidePeriod";
   }
 }
+
+// Mobile offline: periodId omitted and no period covers the given date.
+export class DispatchPeriodNotFoundForDate extends ValidationError {
+  constructor(date: Date) {
+    super(
+      `No se encontró un período fiscal para la fecha ${date.toISOString().slice(0, 10)}`,
+      "FISCAL_PERIOD_NOT_FOUND_FOR_DATE",
+      { date: date.toISOString().slice(0, 10) },
+    );
+    this.name = "DispatchPeriodNotFoundForDate";
+  }
+}

--- a/modules/dispatch/domain/ports/dispatch-fiscal-periods.port.ts
+++ b/modules/dispatch/domain/ports/dispatch-fiscal-periods.port.ts
@@ -16,4 +16,14 @@ export interface DispatchFiscalPeriodsPort {
     organizationId: string,
     periodId: string,
   ): Promise<DispatchFiscalPeriod>;
+
+  /**
+   * Resolves the fiscal period that contains the given date.
+   * Returns null when no period covers that date (mobile offline: missing period).
+   * Used by create/createAndPost when the caller omits periodId.
+   */
+  findByDate(
+    organizationId: string,
+    date: Date,
+  ): Promise<DispatchFiscalPeriod | null>;
 }

--- a/modules/dispatch/domain/ports/dispatch.repository.ts
+++ b/modules/dispatch/domain/ports/dispatch.repository.ts
@@ -91,4 +91,14 @@ export interface DispatchRepository {
     organizationId: string,
     source: Dispatch,
   ): Promise<Dispatch>;
+
+  /**
+   * Looks up a dispatch by mobile idempotency key.
+   * Returns null when clientId is not found (new call) or the repository
+   * implementation doesn't support idempotency (should not happen in production).
+   */
+  findByClientId(
+    organizationId: string,
+    clientId: string,
+  ): Promise<Dispatch | null>;
 }

--- a/modules/dispatch/infrastructure/legacy-fiscal-periods.adapter.ts
+++ b/modules/dispatch/infrastructure/legacy-fiscal-periods.adapter.ts
@@ -28,4 +28,19 @@ export class LegacyFiscalPeriodsAdapter implements DispatchFiscalPeriodsPort {
       endDate: period.endDate,
     };
   }
+
+  async findByDate(
+    organizationId: string,
+    date: Date,
+  ): Promise<DispatchFiscalPeriod | null> {
+    const period = await this.service.findByDate(organizationId, date);
+    if (!period) return null;
+    return {
+      id: period.id,
+      name: period.name,
+      status: period.status.value,
+      startDate: period.startDate,
+      endDate: period.endDate,
+    };
+  }
 }

--- a/modules/dispatch/infrastructure/prisma-dispatch.repository.ts
+++ b/modules/dispatch/infrastructure/prisma-dispatch.repository.ts
@@ -164,6 +164,7 @@ function toDomainDispatch(row: Record<string, unknown>): Dispatch {
       row.totalShortageKg !== null ? Number(row.totalShortageKg) : null,
     totalRealNetKg:
       row.totalRealNetKg !== null ? Number(row.totalRealNetKg) : null,
+    clientId: (row.clientId as string | null) ?? null,
   };
 
   return Dispatch.fromPersistence(props);
@@ -262,6 +263,7 @@ export class PrismaDispatchRepository implements DispatchRepository {
         notes: dispatch.notes,
         farmOrigin: dispatch.farmOrigin,
         chickenCount: dispatch.chickenCount,
+        clientId: dispatch.clientId,
         shrinkagePct:
           dispatch.shrinkagePct !== null
             ? new Prisma.Decimal(dispatch.shrinkagePct)
@@ -461,6 +463,18 @@ export class PrismaDispatchRepository implements DispatchRepository {
       },
     });
     return this.findById(organizationId, id) as Promise<Dispatch>;
+  }
+
+  async findByClientId(
+    organizationId: string,
+    clientId: string,
+  ): Promise<Dispatch | null> {
+    const row = await this.db.dispatch.findFirst({
+      where: { organizationId, clientId },
+      include: dispatchDetailInclude,
+    });
+    if (!row) return null;
+    return toDomainDispatch(row as unknown as Record<string, unknown>);
   }
 
   async cloneToDraftTx(

--- a/modules/dispatch/presentation/__tests__/dispatch-schemas-mobile.test.ts
+++ b/modules/dispatch/presentation/__tests__/dispatch-schemas-mobile.test.ts
@@ -1,0 +1,100 @@
+/**
+ * TDD RED → GREEN — mobile offline contract tests.
+ *
+ * Change A: boxes >= 0 (trozado sin cajas)
+ * Change B: periodId optional in createDispatchSchema
+ * Change C: clientId optional in createDispatchSchema
+ */
+import { describe, it, expect } from "vitest";
+import { createDispatchSchema } from "../schemas/dispatch.schemas";
+
+// ── Shared helpers ─────────────────────────────────────────────────────────
+
+const BASE_DETAIL = {
+  description: "Pollo entero",
+  boxes: 5,
+  grossWeight: 100,
+  unitPrice: 15,
+  order: 0,
+};
+
+const BASE_DISPATCH = {
+  dispatchType: "NOTA_DESPACHO" as const,
+  date: new Date("2026-05-19"),
+  contactId: "contact-1",
+  periodId: "period-1",
+  description: "Despacho test",
+  details: [BASE_DETAIL],
+};
+
+// ── Change A: boxes >= 0 ───────────────────────────────────────────────────
+
+describe("dispatchDetailSchema — boxes >= 0 (change A)", () => {
+  it("rejects boxes = -1", () => {
+    const result = createDispatchSchema.safeParse({
+      ...BASE_DISPATCH,
+      details: [{ ...BASE_DETAIL, boxes: -1 }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts boxes = 0 (trozado sin cajas)", () => {
+    const result = createDispatchSchema.safeParse({
+      ...BASE_DISPATCH,
+      details: [{ ...BASE_DETAIL, boxes: 0 }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts boxes = 1 (retrocompatible)", () => {
+    const result = createDispatchSchema.safeParse({
+      ...BASE_DISPATCH,
+      details: [{ ...BASE_DETAIL, boxes: 1 }],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ── Change B: periodId optional ────────────────────────────────────────────
+
+describe("createDispatchSchema — periodId optional (change B)", () => {
+  it("accepts payload without periodId (mobile offline)", () => {
+    const { periodId: _p, ...withoutPeriodId } = BASE_DISPATCH;
+    const result = createDispatchSchema.safeParse(withoutPeriodId);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.periodId).toBeUndefined();
+    }
+  });
+
+  it("accepts payload with periodId (web retrocompatible)", () => {
+    const result = createDispatchSchema.safeParse(BASE_DISPATCH);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.periodId).toBe("period-1");
+    }
+  });
+});
+
+// ── Change C: clientId optional ────────────────────────────────────────────
+
+describe("createDispatchSchema — clientId optional (change C)", () => {
+  it("accepts payload without clientId (web, retrocompatible)", () => {
+    const result = createDispatchSchema.safeParse(BASE_DISPATCH);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.clientId).toBeUndefined();
+    }
+  });
+
+  it("accepts payload with clientId UUID (mobile)", () => {
+    const result = createDispatchSchema.safeParse({
+      ...BASE_DISPATCH,
+      clientId: "550e8400-e29b-41d4-a716-446655440000",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.clientId).toBe("550e8400-e29b-41d4-a716-446655440000");
+    }
+  });
+});

--- a/modules/dispatch/presentation/schemas/dispatch.schemas.ts
+++ b/modules/dispatch/presentation/schemas/dispatch.schemas.ts
@@ -4,7 +4,7 @@ const dispatchDetailSchema = z.object({
   productTypeId: z.string().min(1).optional(),
   detailNote: z.string().max(200).optional(),
   description: z.string().min(1).max(200),
-  boxes: z.number().int().min(1),
+  boxes: z.number().int().min(0), // 0 allowed: trozado sin cajas (mobile)
   grossWeight: z.number().positive(),
   unitPrice: z.number().positive(),
   shortage: z.number().min(0).optional(), // BC only: faltante
@@ -15,7 +15,9 @@ export const createDispatchSchema = z.object({
   dispatchType: z.enum(["NOTA_DESPACHO", "BOLETA_CERRADA"]),
   date: z.coerce.date(),
   contactId: z.string().min(1),
-  periodId: z.string().min(1),
+  // periodId is optional: mobile offline omits it and the service resolves it
+  // from the date; the web always sends it explicitly (retrocompatible).
+  periodId: z.string().min(1).optional(),
   description: z.string().min(1).max(500),
   referenceNumber: z.number().int().positive().optional(),
   notes: z.string().optional(),
@@ -23,6 +25,9 @@ export const createDispatchSchema = z.object({
   chickenCount: z.number().int().positive().optional(),
   shrinkagePct: z.number().min(0).max(100).optional(),
   details: z.array(dispatchDetailSchema).min(0),
+  // clientId: mobile app generates a UUID per sale for idempotency;
+  // web omits it (retrocompatible). The service deduplicates on this key.
+  clientId: z.string().optional(),
 });
 
 export const updateDispatchSchema = z.object({

--- a/modules/permissions/application/__tests__/permissions.bearer.test.ts
+++ b/modules/permissions/application/__tests__/permissions.bearer.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Fase B (app móvil): el gate `requirePermission` debe autorizar las requests
+ * Bearer SIN org activa (caso F2: el móvil manda el orgSlug por URL y su JWT no
+ * trae org_id) derivando la org del slug + membership (requireOrgAccess), sin
+ * pasar por el lazy-sync `ensure` (que necesita el clerkOrgId de la sesión).
+ *
+ * El flujo web queda intacto: con org activa corre `ensure`; sin org activa y
+ * sin Bearer (cookie web sin org) sigue dando 403.
+ *
+ * Mockeamos toda la cadena pesada con stubs estáticos (espejo de
+ * permissions.smoke.test.ts) para no cargar Prisma ni el SDK de Clerk.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockRequireAuth, mockEnsure, mockRequireOrgAccess, mockRequireRole } =
+  vi.hoisted(() => ({
+    mockRequireAuth: vi.fn(),
+    mockEnsure: vi.fn(async () => ({ orgId: "ignored" })),
+    mockRequireOrgAccess: vi.fn(async () => "org-db-1"),
+    mockRequireRole: vi.fn(async () => ({ role: "owner" })),
+  }));
+
+vi.mock("@/lib/prisma", () => ({ prisma: {} }));
+
+vi.mock("@/features/shared/middleware", () => ({
+  requireAuth: mockRequireAuth,
+}));
+
+vi.mock("@/modules/organizations/presentation/server", () => ({
+  requireOrgAccess: mockRequireOrgAccess,
+  requireRole: mockRequireRole,
+}));
+
+vi.mock("@/modules/organizations/presentation/composition-root", () => ({
+  makeEnsureFromClerkService: () => ({ ensure: mockEnsure }),
+}));
+
+vi.mock("@/modules/permissions/infrastructure/permissions.cache", () => ({
+  ensureOrgSeeded: vi.fn(async () => ({ roles: new Map() })),
+  getMatrix: vi.fn(async () => ({ roles: new Map() })),
+}));
+
+import { requirePermission } from "../permissions.server";
+import { ForbiddenError } from "@/modules/shared/domain/errors";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockEnsure.mockResolvedValue({ orgId: "ignored" });
+  mockRequireOrgAccess.mockResolvedValue("org-db-1");
+  mockRequireRole.mockResolvedValue({ role: "owner" });
+});
+
+describe("requirePermission — request Bearer sin org activa (app móvil)", () => {
+  beforeEach(() => {
+    mockRequireAuth.mockResolvedValue({
+      userId: "u-mobile",
+      orgId: null,
+      viaBearer: true,
+    });
+  });
+
+  it("NO corre el lazy-sync ensure (no hay clerkOrgId en el token)", async () => {
+    await requirePermission("dispatches", "write", "mi-org");
+    expect(mockEnsure).not.toHaveBeenCalled();
+  });
+
+  it("autoriza por orgSlug de la URL + membership (requireOrgAccess)", async () => {
+    const result = await requirePermission("dispatches", "write", "mi-org");
+    expect(mockRequireOrgAccess).toHaveBeenCalledWith("u-mobile", "mi-org");
+    expect(result.orgId).toBe("org-db-1");
+  });
+});
+
+describe("requirePermission — flujo web intacto", () => {
+  it("con org activa corre el lazy-sync ensure (cookie web)", async () => {
+    mockRequireAuth.mockResolvedValue({
+      userId: "u-web",
+      orgId: "clerk-org-1",
+      viaBearer: false,
+    });
+
+    await requirePermission("dispatches", "write", "mi-org");
+
+    expect(mockEnsure).toHaveBeenCalledWith("clerk-org-1", "u-web");
+    expect(mockRequireOrgAccess).toHaveBeenCalledWith("u-web", "mi-org");
+  });
+
+  it("cookie web SIN org activa sigue dando 403 (comportamiento original)", async () => {
+    mockRequireAuth.mockResolvedValue({
+      userId: "u-web",
+      orgId: null,
+      viaBearer: false,
+    });
+
+    await expect(
+      requirePermission("dispatches", "write", "mi-org"),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+    expect(mockEnsure).not.toHaveBeenCalled();
+    expect(mockRequireOrgAccess).not.toHaveBeenCalled();
+  });
+});

--- a/modules/permissions/application/permissions.server.ts
+++ b/modules/permissions/application/permissions.server.ts
@@ -47,10 +47,17 @@ export async function requirePermission(
   // member ya existen local) son 2 reads DB, sin pegar a Clerk. Sólo paga
   // el costo de Clerk API la primera vez tras borrar la tabla. Modo
   // restrictivo: el primer init exige Clerk-owner; ver EnsureFromClerkService.
-  if (!session.orgId) {
+  //
+  // Requiere el clerkOrgId de la org ACTIVA de la sesión (flujo web). Los
+  // clientes externos por Bearer (app móvil, Fase B) no traen org activa: el
+  // orgSlug viaja por la URL y la org+member ya existen en BD (creados desde la
+  // web), así que se omite el ensure y se autoriza directo por slug + membership.
+  if (session.orgId) {
+    await makeEnsureFromClerkService().ensure(session.orgId, session.userId);
+  } else if (!session.viaBearer) {
+    // Sesión web sin org activa → 403, igual que antes.
     throw new ForbiddenError();
   }
-  await makeEnsureFromClerkService().ensure(session.orgId, session.userId);
 
   const orgId = await requireOrgAccess(session.userId, orgSlug);
 

--- a/modules/shared/presentation/__tests__/c1-shape.poc-shared-middleware-auth.test.ts
+++ b/modules/shared/presentation/__tests__/c1-shape.poc-shared-middleware-auth.test.ts
@@ -91,14 +91,14 @@ describe("α2–α8 hex middleware.ts content sentinels", () => {
     expect(content).toMatch(/UnauthorizedError/);
   });
 
-  it("α7: hex middleware line count matches features source (10 LOC)", () => {
+  it("α7: hex middleware line count is 48 LOC (era 10; +38 por el fallback Bearer para la app móvil — Fase B mobile-bearer-cors)", () => {
     const content = readFileSync(HEX_MIDDLEWARE, "utf-8");
     const lines = content.split("\n").filter((_, i, arr) => {
       // exclude trailing empty line from count
       if (i === arr.length - 1 && arr[i] === "") return false;
       return true;
     });
-    expect(lines.length).toBe(10);
+    expect(lines.length).toBe(48);
   });
 
   it("α8: hex middleware has no @/features import (arch boundary absence)", () => {

--- a/modules/shared/presentation/__tests__/middleware.bearer.test.ts
+++ b/modules/shared/presentation/__tests__/middleware.bearer.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Fase B (app móvil): `requireAuth` debe aceptar el session token de Clerk por
+ * el header `Authorization: Bearer <jwt>` cuando no hay sesión por cookie, sin
+ * romper el flujo web (cookie) existente. Normaliza el retorno a
+ * { userId, orgId, viaBearer } — verificado: ningún llamador usa otros campos.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockAuth, mockVerifyToken, mockHeadersGet } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockVerifyToken: vi.fn(),
+  mockHeadersGet: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: mockAuth,
+  verifyToken: mockVerifyToken,
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => ({ get: mockHeadersGet })),
+}));
+
+import { requireAuth } from "../middleware";
+import { UnauthorizedError } from "@/modules/shared/domain/errors";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockHeadersGet.mockReturnValue(null);
+  process.env.CLERK_SECRET_KEY = "sk_test_dummy";
+});
+
+describe("requireAuth — sesión por cookie (web)", () => {
+  it("devuelve userId+orgId de auth() con viaBearer=false y no toca el header", async () => {
+    mockAuth.mockResolvedValue({ userId: "u1", orgId: "o1" });
+
+    const r = await requireAuth();
+
+    expect(r).toEqual({ userId: "u1", orgId: "o1", viaBearer: false });
+    expect(mockVerifyToken).not.toHaveBeenCalled();
+  });
+
+  it("orgId null cuando la sesión web no tiene org activa", async () => {
+    mockAuth.mockResolvedValue({ userId: "u1", orgId: null });
+
+    const r = await requireAuth();
+
+    expect(r).toEqual({ userId: "u1", orgId: null, viaBearer: false });
+  });
+});
+
+describe("requireAuth — fallback Bearer (app móvil)", () => {
+  beforeEach(() => {
+    mockAuth.mockResolvedValue({ userId: null });
+  });
+
+  it("verifica el JWT del header y devuelve userId+orgId con viaBearer=true", async () => {
+    mockHeadersGet.mockReturnValue("Bearer tok123");
+    mockVerifyToken.mockResolvedValue({ sub: "u2", org_id: "o2" });
+
+    const r = await requireAuth();
+
+    expect(mockVerifyToken).toHaveBeenCalledWith(
+      "tok123",
+      expect.objectContaining({ secretKey: "sk_test_dummy" }),
+    );
+    expect(r).toEqual({ userId: "u2", orgId: "o2", viaBearer: true });
+  });
+
+  it("orgId null cuando el JWT no trae claim de organización (caso F2: org diferida)", async () => {
+    mockHeadersGet.mockReturnValue("Bearer tok123");
+    mockVerifyToken.mockResolvedValue({ sub: "u3" });
+
+    const r = await requireAuth();
+
+    expect(r).toEqual({ userId: "u3", orgId: null, viaBearer: true });
+  });
+
+  it("401 si no hay sesión por cookie ni header Bearer", async () => {
+    mockHeadersGet.mockReturnValue(null);
+
+    await expect(requireAuth()).rejects.toBeInstanceOf(UnauthorizedError);
+    expect(mockVerifyToken).not.toHaveBeenCalled();
+  });
+
+  it("401 si el token Bearer es inválido (verifyToken lanza)", async () => {
+    mockHeadersGet.mockReturnValue("Bearer bad");
+    mockVerifyToken.mockRejectedValue(new Error("invalid token"));
+
+    await expect(requireAuth()).rejects.toBeInstanceOf(UnauthorizedError);
+  });
+});

--- a/modules/shared/presentation/middleware.ts
+++ b/modules/shared/presentation/middleware.ts
@@ -1,10 +1,48 @@
-import { auth } from "@clerk/nextjs/server";
+import { auth, verifyToken } from "@clerk/nextjs/server";
+import { headers } from "next/headers";
 import { UnauthorizedError } from "@/modules/shared/domain/errors";
 
 export { handleError } from "./http-error-serializer";
 
-export async function requireAuth() {
+/**
+ * Identidad resuelta de una request. Normalizada para servir tanto al flujo web
+ * (sesión por cookie de Clerk) como a clientes externos (app móvil) que mandan
+ * el session token por `Authorization: Bearer`. Solo expone lo que consumen los
+ * llamadores: `userId` y `orgId` (la org activa, si la hay).
+ */
+export interface AuthContext {
+  userId: string;
+  /** Org activa de la sesión. `null` para Bearer sin org (caso F2: org por slug). */
+  orgId: string | null;
+  /** `true` si la identidad vino por header Bearer (cliente externo, p.ej. el celu). */
+  viaBearer: boolean;
+}
+
+export async function requireAuth(): Promise<AuthContext> {
+  // Camino web: sesión por cookie. clerkMiddleware ya la cargó.
   const session = await auth();
-  if (!session.userId) throw new UnauthorizedError();
-  return session;
+  if (session.userId) {
+    return { userId: session.userId, orgId: session.orgId ?? null, viaBearer: false };
+  }
+
+  // Fallback para clientes externos (app móvil Expo): el session token de Clerk
+  // viaja en `Authorization: Bearer <jwt>`. Se verifica con la MISMA instancia
+  // (CLERK_SECRET_KEY) que ya usa la web — mismo issuer, mismo JWKS.
+  const authorization = (await headers()).get("authorization");
+  const token = authorization?.match(/^Bearer (.+)$/)?.[1];
+  if (!token) throw new UnauthorizedError();
+
+  try {
+    const claims = await verifyToken(token, {
+      secretKey: process.env.CLERK_SECRET_KEY,
+    });
+    return {
+      userId: claims.sub,
+      orgId: claims.org_id ?? null,
+      viaBearer: true,
+    };
+  } catch {
+    // Token ausente del set válido, expirado o firma inválida → 401.
+    throw new UnauthorizedError();
+  }
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -21,6 +21,27 @@ const nextConfig: NextConfig = {
           { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
         ],
       },
+      {
+        // CORS para clientes externos (app móvil Expo) que consumen la API.
+        // Origin `*` es seguro acá: la auth es por Bearer (header Authorization),
+        // NO por cookies, así que no se necesita Allow-Credentials. El fetch
+        // nativo de Android ignora CORS; esto habilita además pruebas en Expo web.
+        // Nota: el preflight OPTIONS en browser requeriría un handler propio —
+        // fuera de alcance mientras el cliente sea nativo.
+        source: '/api/:path*',
+        headers: [
+          { key: 'Access-Control-Allow-Origin', value: '*' },
+          {
+            key: 'Access-Control-Allow-Methods',
+            value: 'GET, POST, PATCH, DELETE, OPTIONS',
+          },
+          {
+            key: 'Access-Control-Allow-Headers',
+            value: 'Authorization, Content-Type',
+          },
+          { key: 'Access-Control-Max-Age', value: '86400' },
+        ],
+      },
     ];
   },
   async redirects() {

--- a/prisma/migrations/20260522190000_dispatch_client_id_idempotency/migration.sql
+++ b/prisma/migrations/20260522190000_dispatch_client_id_idempotency/migration.sql
@@ -1,0 +1,13 @@
+-- mobile-bearer-cors Phase — dispatch_client_id_idempotency
+-- Adds optional clientId to dispatches for mobile offline idempotency (change C).
+-- A unique index scoped to (organizationId, clientId) ensures a mobile client
+-- UUID can only produce one dispatch per org.
+-- Postgres treats each NULL as distinct in a unique index, so web dispatches
+-- (clientId = NULL) are never affected by this constraint.
+
+-- Step 1: Add nullable clientId column
+ALTER TABLE "dispatches" ADD COLUMN "clientId" TEXT;
+
+-- Step 2: Create unique index — NULLs do not collide in Postgres
+CREATE UNIQUE INDEX "dispatches_organizationId_clientId_key"
+  ON "dispatches"("organizationId", "clientId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -724,6 +724,9 @@ model Dispatch {
   journalEntryId  String?        @unique
   receivableId    String?        @unique
   notes           String?
+  // Mobile offline idempotency key — nullable so multiple web dispatches (null)
+  // don't collide; Postgres treats each NULL as distinct in a unique index.
+  clientId        String?
   createdById     String
   createdAt       DateTime       @db.Timestamptz(3) @default(now())
   updatedAt       DateTime       @db.Timestamptz(3) @updatedAt
@@ -736,6 +739,7 @@ model Dispatch {
   details         DispatchDetail[]
 
   @@unique([organizationId, dispatchType, sequenceNumber])
+  @@unique([organizationId, clientId])
   @@index([organizationId, status])
   @@index([organizationId, contactId])
   @@index([organizationId, date])


### PR DESCRIPTION
## Qué hace

Habilita que la app móvil (Expo) consuma esta API: autenticación por **Bearer** (token de sesión de Clerk), **CORS**, y un contrato de despachos apto para captura offline. La web queda **idéntica**.

## Cambios

**1. Bearer auth + CORS**
- `requireAuth()` acepta `Authorization: Bearer <jwt>` cuando no hay cookie, verificándolo con `verifyToken` (ya exportado por `@clerk/nextjs/server` — sin dependencia nueva). Retorno normalizado a `{ userId, orgId, viaBearer }`.
- `requirePermission()`: el camino Bearer sin org activa autoriza por `orgSlug` de la URL + membership (`requireOrgAccess`), salteando el lazy-sync `ensure`. Flujo web sin tocar.
- CORS `Access-Control-*` para `/api/:path*` (origin `*`, seguro: auth por header, no cookies).

**2. Contrato de dispatch mobile-friendly**
- `periodId` opcional: si el cliente no lo manda, se resuelve por la fecha (`findByDate`). La web lo sigue enviando.
- `boxes >= 0` (antes `>= 1`): soporta líneas de trozado sin cajas.
- **Idempotencia**: `Dispatch.clientId` (nullable) + `@@unique([organizationId, clientId])`. `create()` deduplica por `clientId` (early-return + recovery race-safe ante `P2002`) → un reintento del celular no duplica.

## Compatibilidad
Retrocompatible con la web: `clientId` null y `periodId` presente siguen el camino de siempre.

## Testing
TDD en ambos commits. `tsc --noEmit` limpio. Suites afectadas verdes (el único rojo, `α18` de conteo de `vi.mock`, es drift pre-existente en `master`, ajeno a este cambio).

## Deploy
Incluye migración Prisma `20260522190000_dispatch_client_id_idempotency` (ADD COLUMN nullable + UNIQUE INDEX, aditiva). Requiere `prisma migrate deploy` al desplegar.