### PR TITLE
fix(tests): repair three pre-existing flaky/stale test issues

### DIFF
--- a/components/payments/__tests__/payment-form-shortcut.test.tsx
+++ b/components/payments/__tests__/payment-form-shortcut.test.tsx
@@ -89,16 +89,21 @@ afterEach(() => {
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
+// PaymentForm seeds its date from todayLocal() (the real clock), so a hardcoded
+// month silently breaks this fixture as wall-clock drifts past it — this file was
+// pinned to May 2026 and went red once "today" left that month. Derive the period
+// from the current month so it always covers whatever date the form defaults to.
+const TODAY = new Date();
 const BASE_PERIOD = {
   id: "period-1",
-  name: "Mayo 2026",
-  startDate: new Date("2026-05-01"),
-  endDate: new Date("2026-05-31"),
+  name: "Periodo actual",
+  startDate: new Date(TODAY.getFullYear(), TODAY.getMonth(), 1),
+  endDate: new Date(TODAY.getFullYear(), TODAY.getMonth() + 1, 0),
   status: "OPEN" as const,
   organizationId: "org-1",
-  year: 2026,
+  year: TODAY.getFullYear(),
   createdById: "user-1",
-  month: 5,
+  month: TODAY.getMonth() + 1,
   closedAt: null,
   closedBy: null,
   createdAt: new Date(),

--- a/modules/permissions/application/__tests__/c1-shape.poc-permissions-hex-b3.test.ts
+++ b/modules/permissions/application/__tests__/c1-shape.poc-permissions-hex-b3.test.ts
@@ -237,16 +237,16 @@ describe("α18 RETIREMENT sentinel — deprecated @/features/permissions/server 
     //   passed in the full suite but FAILED in isolation. The dead async-importOriginal mock was
     //   removed, leaving the single plain factory. So 84 consumer FILES = 84 matched LINES now.
     //   Verified: zero new/unauthorized consumers added → the legitimate count is 84.
-    const oldCmd = `grep -rE "vi\\.mock\\(\\s*['\\"]@/features/permissions/server['\\"]" "${ROOT}" --include="*.test.ts" --include="*.tsx" 2>/dev/null | grep -v "c1-shape.poc-permissions-hex-b3.test.ts" | wc -l`;
+    const oldCmd = `grep -rE "vi\\.mock\\(\\s*['\\"]@/features/permissions/server['\\"]" "${ROOT}" --include="*.test.ts" --include="*.tsx" --exclude-dir=node_modules --exclude-dir=.next --exclude-dir=.git 2>/dev/null | grep -v "c1-shape.poc-permissions-hex-b3.test.ts" | wc -l`;
     const oldCount = Number(execSync(oldCmd, { encoding: "utf-8" }).trim());
     // KEY retirement sentinel: the deprecated SHIM path has ZERO remaining mock consumers.
     expect(oldCount).toBe(0);
 
-    const newCmd = `grep -rE "vi\\.mock\\(\\s*['\\"]@/modules/permissions/application/server['\\"]" "${ROOT}" --include="*.test.ts" --include="*.tsx" 2>/dev/null | grep -v "c1-shape.poc-permissions-hex-b3.test.ts" | wc -l`;
+    const newCmd = `grep -rE "vi\\.mock\\(\\s*['\\"]@/modules/permissions/application/server['\\"]" "${ROOT}" --include="*.test.ts" --include="*.tsx" --exclude-dir=node_modules --exclude-dir=.next --exclude-dir=.git 2>/dev/null | grep -v "c1-shape.poc-permissions-hex-b3.test.ts" | wc -l`;
     const newCount = Number(execSync(newCmd, { encoding: "utf-8" }).trim());
     // Confirmation: the mocks were REPOINTED to hex, not deleted.
     expect(newCount).toBeGreaterThan(0);
-  });
+  }, 30000);
 });
 
 // ── α19: RETIREMENT — SHIM features/permissions/server.ts deleted; hex is canonical ─

--- a/tests/stress/basic.js
+++ b/tests/stress/basic.js
@@ -12,7 +12,7 @@ export const options = {
 
 const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
 
-export default function () {
+export default function basicLoadTest() {
   const res = http.get(`${BASE_URL}/`);
 
   check(res, {

--- a/tests/stress/ramp.js
+++ b/tests/stress/ramp.js
@@ -21,7 +21,7 @@ export const options = {
 
 const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
 
-export default function () {
+export default function rampLoadTest() {
   const homeRes = http.get(`${BASE_URL}/`);
   check(homeRes, {
     'home: status 200': (r) => r.status === 200,

--- a/tests/stress/stress.js
+++ b/tests/stress/stress.js
@@ -16,7 +16,7 @@ export const options = {
 
 const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
 
-export default function () {
+export default function stressLoadTest() {
   const res = http.get(`${BASE_URL}/`);
   check(res, {
     'status es 200 o 503': (r) => r.status === 200 || r.status === 503,


### PR DESCRIPTION
Surfaced by the PR #7 hex-paydown audit. **None are regressions from that PR** — all three are pre-existing issues the audit caught.

## Corrections
- **α18 permissions sentinel** (`c1-shape.poc-permissions-hex-b3.test.ts`): the repo-wide `grep` walked `node_modules` (no `--exclude-dir`), blowing past vitest's 5000ms default under parallel load → intermittent CI red. Excluded `node_modules/.next/.git` + added a 30s margin. **5000ms timeout → 304ms.**
- **payment-form shortcut** (`payment-form-shortcut.test.tsx`): `BASE_PERIOD` was hardcoded to May 2026 while the form seeds its date from `todayLocal()`. Wall-clock drift left "today" with no covering fiscal period, disabling submit → 3 tests red. Now derives the period from the current month. Also makes `T-18.a` exercise the `amount>max` guard for real (still green — no hidden component bug).
- **k6 stress scripts** (`tests/stress/*.js`): named the default-export functions to clear `import/no-anonymous-default-export`.

## Verification
- Suite: **4 failing → 0** (784/784 files, 7309/7309 tests)
- Ratchet baseline **101 unchanged**
- `tsc --noEmit`: 0 errors
- No production code touched