### PR TITLE
refactor(hex): prisma-free presentation via module read ports

### DIFF
--- a/app/(dashboard)/[orgSlug]/accounting/monthly-close/__tests__/close-event-viewer.test.ts
+++ b/app/(dashboard)/[orgSlug]/accounting/monthly-close/__tests__/close-event-viewer.test.ts
@@ -7,17 +7,25 @@
  * (c) On authorized → page does not redirect.
  *
  * Fails until T60 creates close-event/page.tsx.
+ *
+ * FLIPPED (audit-pure-read Group B): this test historically mocked
+ * `@/lib/prisma` (`prisma.auditLog.findMany`) — the page's direct read. The
+ * read now lives behind the audit-owned `AuditCloseEventReaderPort` exposed
+ * via `makeAuditReads()`, so the test mocks the composition root instead of
+ * reaching through the Prisma adapter internals.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 
-const { mockRedirect, mockRequirePermission, mockFindMany } = vi.hoisted(() => ({
-  mockRedirect: vi.fn(),
-  mockRequirePermission: vi.fn(),
-  mockFindMany: vi.fn(),
-}));
+const { mockRedirect, mockRequirePermission, mockListByCorrelation } = vi.hoisted(
+  () => ({
+    mockRedirect: vi.fn(),
+    mockRequirePermission: vi.fn(),
+    mockListByCorrelation: vi.fn(),
+  }),
+);
 
 vi.mock("next/navigation", () => ({ redirect: mockRedirect }));
 
@@ -25,12 +33,10 @@ vi.mock("@/modules/permissions/application/server", () => ({
   requirePermission: mockRequirePermission,
 }));
 
-vi.mock("@/lib/prisma", () => ({
-  prisma: {
-    auditLog: {
-      findMany: mockFindMany,
-    },
-  },
+vi.mock("@/modules/audit/presentation/server", () => ({
+  makeAuditReads: () => ({
+    closeEvents: { listByCorrelation: mockListByCorrelation },
+  }),
 }));
 
 // ── Import after mocks ────────────────────────────────────────────────────────
@@ -53,7 +59,7 @@ function makeSearchParams(correlationId?: string) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockFindMany.mockResolvedValue([]);
+  mockListByCorrelation.mockResolvedValue([]);
 });
 
 describe("/accounting/monthly-close/close-event — CloseEventPage RBAC", () => {

--- a/app/(dashboard)/[orgSlug]/accounting/monthly-close/close-event/__tests__/page-hex-purity.test.ts
+++ b/app/(dashboard)/[orgSlug]/accounting/monthly-close/close-event/__tests__/page-hex-purity.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Audit-pure-read (Group B) sentinel: close-event/page.tsx MUST NOT import
+ * `@/lib/prisma` (zero direct Prisma reads — pure hexagonal page). Mirror the
+ * sale-pure-read pilot sentinel
+ * (`app/(dashboard)/[orgSlug]/sales/[saleId]/__tests__/page-hex-purity.test.ts`).
+ *
+ * The direct close-event audit read (`prisma.auditLog.findMany` by
+ * correlationId) moved behind the audit-owned read port
+ * (`AuditCloseEventReaderPort`) with a Prisma adapter in
+ * `modules/audit/infrastructure`, exposed via `makeAuditReads()` in the audit
+ * composition-root.
+ *
+ * RED expected failure mode: page.tsx imports `{ prisma } from "@/lib/prisma"`
+ * and invokes `prisma.auditLog.findMany` → greps MUST be ZERO; FAILS today.
+ * GREEN: page consumes `makeAuditReads()` instead.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ROOT = resolve(__dirname, "..", "..", "..", "..", "..", "..", "..");
+const PAGE = resolve(
+  ROOT,
+  "app/(dashboard)/[orgSlug]/accounting/monthly-close/close-event/page.tsx",
+);
+
+describe("audit-pure-read Group B — close-event page hex purity", () => {
+  it("page.tsx does NOT import @/lib/prisma nor reference the prisma client", () => {
+    const src = readFileSync(PAGE, "utf8");
+    expect(src).not.toMatch(/@\/lib\/prisma/);
+    expect(src).not.toMatch(/\bprisma\./);
+  });
+
+  it("page.tsx consumes the audit read facade (makeAuditReads) from the composition-root", () => {
+    const src = readFileSync(PAGE, "utf8");
+    expect(src).toMatch(/\bmakeAuditReads\b/);
+  });
+});

--- a/app/(dashboard)/[orgSlug]/accounting/monthly-close/close-event/page.tsx
+++ b/app/(dashboard)/[orgSlug]/accounting/monthly-close/close-event/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation";
 import { requirePermission } from "@/modules/permissions/application/server";
-import { prisma } from "@/lib/prisma";
+import { makeAuditReads } from "@/modules/audit/presentation/server";
 
 interface CloseEventPageProps {
   params: Promise<{ orgSlug: string }>;
@@ -52,10 +52,13 @@ export default async function CloseEventPage({
     );
   }
 
-  const rows = await prisma.auditLog.findMany({
-    where: { organizationId: orgId, correlationId },
-    orderBy: [{ entityType: "asc" }, { createdAt: "asc" }],
-  });
+  // Registros del evento de cierre via tenant-scoped read port del módulo
+  // audit (audit-pure-read Group B). Ya llegan ordenados por entityType +
+  // createdAt.
+  const rows = await makeAuditReads().closeEvents.listByCorrelation(
+    orgId,
+    correlationId,
+  );
 
   // Group by entityType
   const grouped = rows.reduce<Record<string, typeof rows>>((acc, row) => {

--- a/app/(dashboard)/[orgSlug]/audit/__tests__/page-hex-purity.test.ts
+++ b/app/(dashboard)/[orgSlug]/audit/__tests__/page-hex-purity.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Audit-pure-read (Group B) sentinel: audit/page.tsx MUST NOT import
+ * `@/lib/prisma` (zero direct Prisma reads — pure hexagonal page). Mirror the
+ * sale-pure-read pilot sentinel
+ * (`app/(dashboard)/[orgSlug]/sales/[saleId]/__tests__/page-hex-purity.test.ts`).
+ *
+ * The direct members read (`prisma.organizationMember.findMany` for the user
+ * filter select) moved behind the audit-owned read port
+ * (`AuditOrgMembersReaderPort`) with a Prisma adapter in
+ * `modules/audit/infrastructure`, exposed via `makeAuditReads()` in the audit
+ * composition-root.
+ *
+ * RED expected failure mode: page.tsx imports `{ prisma } from "@/lib/prisma"`
+ * and invokes `prisma.organizationMember.findMany` → greps MUST be ZERO; FAILS
+ * today. GREEN: page consumes `makeAuditReads()` instead.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ROOT = resolve(__dirname, "..", "..", "..", "..", "..");
+const PAGE = resolve(ROOT, "app/(dashboard)/[orgSlug]/audit/page.tsx");
+
+describe("audit-pure-read Group B — audit page hex purity", () => {
+  it("page.tsx does NOT import @/lib/prisma nor reference the prisma client", () => {
+    const src = readFileSync(PAGE, "utf8");
+    expect(src).not.toMatch(/@\/lib\/prisma/);
+    expect(src).not.toMatch(/\bprisma\./);
+  });
+
+  it("page.tsx consumes the audit read facade (makeAuditReads) from the composition-root", () => {
+    const src = readFileSync(PAGE, "utf8");
+    expect(src).toMatch(/\bmakeAuditReads\b/);
+  });
+});

--- a/app/(dashboard)/[orgSlug]/audit/page.tsx
+++ b/app/(dashboard)/[orgSlug]/audit/page.tsx
@@ -1,7 +1,10 @@
 import { redirect } from "next/navigation";
-import { prisma } from "@/lib/prisma";
 import { requirePermission } from "@/modules/permissions/application/server";
-import { makeAuditService, parseCursor } from "@/modules/audit/presentation/server";
+import {
+  makeAuditReads,
+  makeAuditService,
+  parseCursor,
+} from "@/modules/audit/presentation/server";
 import type {
   AuditAction,
   AuditCursor,
@@ -82,16 +85,9 @@ export default async function AuditPage({
   // Serializar Dates para el client component (Next.js requirement).
   const initialData = JSON.parse(JSON.stringify(result)) as typeof result;
 
-  // Resolver lista de usuarios activos de la org para el filter select.
-  const members = await prisma.organizationMember.findMany({
-    where: { organizationId: orgId, deactivatedAt: null },
-    include: { user: { select: { id: true, name: true, email: true } } },
-    orderBy: { user: { name: "asc" } },
-  });
-  const users = members.map((m) => ({
-    id: m.user.id,
-    name: m.user.name ?? m.user.email,
-  }));
+  // Resolver lista de usuarios activos de la org para el filter select —
+  // tenant-scoped read port del módulo audit (audit-pure-read Group B).
+  const users = await makeAuditReads().orgMembers.listActive(orgId);
 
   return (
     <div className="space-y-6">

--- a/app/(dashboard)/[orgSlug]/purchases/[purchaseId]/__tests__/page-hex-purity.test.ts
+++ b/app/(dashboard)/[orgSlug]/purchases/[purchaseId]/__tests__/page-hex-purity.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Purchase-pure-read sentinel (mirror sale-pure-read pilot):
+ * purchases/[purchaseId]/page.tsx MUST NOT import `@/lib/prisma` (zero direct
+ * Prisma reads — pure hexagonal page).
+ *
+ * The two direct reads (contact + payable-with-allocations) moved behind
+ * purchase-module read ports (`PurchaseContactReaderPort` /
+ * `PurchasePayableReaderPort`) with Prisma adapters in
+ * `modules/purchase/infrastructure`, exposed via `makePurchaseReads()` in the
+ * purchase composition-root.
+ *
+ * RED expected failure mode (per [[red_acceptance_failure_mode]]): page.tsx
+ * imports `{ prisma } from "@/lib/prisma"` (L8) and invokes
+ * `prisma.contact.findUnique` + `prisma.accountsPayable.findUnique`
+ * (L49-82) → greps MUST be ZERO; FAILS today. GREEN: page consumes
+ * `makePurchaseReads()` instead.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ROOT = resolve(__dirname, "..", "..", "..", "..", "..", "..");
+const PAGE = resolve(
+  ROOT,
+  "app/(dashboard)/[orgSlug]/purchases/[purchaseId]/page.tsx",
+);
+
+describe("purchase-pure-read — purchases/[purchaseId] hex purity", () => {
+  it("page.tsx does NOT import @/lib/prisma nor reference the prisma client", () => {
+    const src = readFileSync(PAGE, "utf8");
+    expect(src).not.toMatch(/@\/lib\/prisma/);
+    expect(src).not.toMatch(/\bprisma\./);
+  });
+
+  it("page.tsx consumes the purchase read facade (makePurchaseReads) from the composition-root", () => {
+    const src = readFileSync(PAGE, "utf8");
+    expect(src).toMatch(/\bmakePurchaseReads\b/);
+  });
+});

--- a/app/(dashboard)/[orgSlug]/purchases/[purchaseId]/__tests__/page-rbac.test.ts
+++ b/app/(dashboard)/[orgSlug]/purchases/[purchaseId]/__tests__/page-rbac.test.ts
@@ -9,6 +9,11 @@
  * A3-C4b.5 sale detail page-rbac mock factory expansion pattern (engram
  * poc-nuevo/a3/c4b-5/closed) — sub-§13 in-flight absorbed inline GREEN
  * (engram-only, NO formal §13.AC-purchase variante 5 cementación).
+ *
+ * Purchase-pure-read (mirror sale-pure-read pilot): the two Prisma direct
+ * deps lookups (contact + payable) moved behind `makePurchaseReads()` read
+ * ports — the `@/lib/prisma` mock is gone; the composition-root mock now also
+ * stubs `makePurchaseReads`.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
@@ -21,9 +26,10 @@ const {
   mockProductTypesList,
   mockAccountsList,
   mockMakePurchaseService,
+  mockMakePurchaseReads,
   mockToPurchaseWithDetails,
-  mockContactFindUnique,
-  mockPayableFindUnique,
+  mockContactFindById,
+  mockPayableFindWithAllocations,
 } = vi.hoisted(() => ({
   mockRedirect: vi.fn(),
   mockRequirePermission: vi.fn(),
@@ -33,9 +39,10 @@ const {
   mockProductTypesList: vi.fn(),
   mockAccountsList: vi.fn(),
   mockMakePurchaseService: vi.fn(),
+  mockMakePurchaseReads: vi.fn(),
   mockToPurchaseWithDetails: vi.fn(),
-  mockContactFindUnique: vi.fn(),
-  mockPayableFindUnique: vi.fn(),
+  mockContactFindById: vi.fn(),
+  mockPayableFindWithAllocations: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({ redirect: mockRedirect }));
@@ -46,17 +53,11 @@ vi.mock("@/modules/permissions/application/server", () => ({
 
 vi.mock("@/modules/purchase/presentation/composition-root", () => ({
   makePurchaseService: mockMakePurchaseService,
+  makePurchaseReads: mockMakePurchaseReads,
 }));
 
 vi.mock("@/modules/purchase/presentation/mappers/purchase-to-with-details.mapper", () => ({
   toPurchaseWithDetails: mockToPurchaseWithDetails,
-}));
-
-vi.mock("@/lib/prisma", () => ({
-  prisma: {
-    contact: { findUnique: mockContactFindUnique },
-    accountsPayable: { findUnique: mockPayableFindUnique },
-  },
 }));
 
 vi.mock("@/modules/contacts/presentation/server", () => {
@@ -96,6 +97,10 @@ function makeParams() {
 beforeEach(() => {
   vi.clearAllMocks();
   mockMakePurchaseService.mockReturnValue({ getById: mockPurchaseGetById });
+  mockMakePurchaseReads.mockReturnValue({
+    contact: { findById: mockContactFindById },
+    payable: { findWithAllocations: mockPayableFindWithAllocations },
+  });
   mockPurchaseGetById.mockResolvedValue({
     id: PURCHASE_ID,
     periodId: PERIOD_ID,
@@ -110,14 +115,14 @@ beforeEach(() => {
   ]);
   mockProductTypesList.mockResolvedValue([]);
   mockAccountsList.mockResolvedValue([]);
-  mockContactFindUnique.mockResolvedValue({
+  mockContactFindById.mockResolvedValue({
     id: CONTACT_ID,
     name: "Test Contact",
     type: "PROVEEDOR",
     nit: null,
     paymentTermsDays: 30,
   });
-  mockPayableFindUnique.mockResolvedValue(null);
+  mockPayableFindWithAllocations.mockResolvedValue(null);
   mockToPurchaseWithDetails.mockReturnValue({});
 });
 

--- a/app/(dashboard)/[orgSlug]/purchases/[purchaseId]/page.tsx
+++ b/app/(dashboard)/[orgSlug]/purchases/[purchaseId]/page.tsx
@@ -5,8 +5,10 @@ import type { Contact } from "@/modules/contacts/presentation/index";
 import { makeFiscalPeriodsService } from "@/modules/fiscal-periods/presentation/server";
 import { makeProductTypeService } from "@/modules/product-type/presentation/server";
 import { makeAccountsService } from "@/modules/accounting/presentation/server";
-import { prisma } from "@/lib/prisma";
-import { makePurchaseService } from "@/modules/purchase/presentation/composition-root";
+import {
+  makePurchaseReads,
+  makePurchaseService,
+} from "@/modules/purchase/presentation/composition-root";
 import { toPurchaseWithDetails } from "@/modules/purchase/presentation/mappers/purchase-to-with-details.mapper";
 import PurchaseForm from "@/components/purchases/purchase-form";
 import type { PurchaseType } from "@/modules/purchase/presentation/dto/purchase-with-details";
@@ -29,6 +31,7 @@ export default async function PurchaseDetailPage({
   }
 
   const purchaseService = makePurchaseService();
+  const purchaseReads = makePurchaseReads();
   const contactsService = makeContactsService();
   const periodsService = makeFiscalPeriodsService();
   const productTypesService = makeProductTypeService();
@@ -46,39 +49,9 @@ export default async function PurchaseDetailPage({
     periodsService.list(orgId).then((entities) => entities.map((p) => p.toSnapshot())),
     productTypesService.list(orgId, { isActive: true }).then((entities) => entities.map((pt) => pt.toSnapshot())),
     accountsService.list(orgId, { type: "GASTO", isDetail: true, isActive: true }),
-    prisma.contact.findUnique({
-      where: { id: purchase.contactId },
-      select: {
-        id: true,
-        name: true,
-        type: true,
-        nit: true,
-        paymentTermsDays: true,
-      },
-    }),
+    purchaseReads.contact.findById(orgId, purchase.contactId),
     purchase.payableId
-      ? prisma.accountsPayable.findUnique({
-          where: { id: purchase.payableId },
-          select: {
-            id: true,
-            amount: true,
-            paid: true,
-            balance: true,
-            status: true,
-            dueDate: true,
-            allocations: {
-              select: {
-                id: true,
-                paymentId: true,
-                amount: true,
-                payment: {
-                  select: { id: true, date: true, description: true },
-                },
-              },
-              orderBy: { payment: { date: "asc" as const } },
-            },
-          },
-        })
+      ? purchaseReads.payable.findWithAllocations(orgId, purchase.payableId)
       : Promise.resolve(null),
   ]);
 

--- a/app/(dashboard)/[orgSlug]/purchases/__tests__/page-hex-purity.test.ts
+++ b/app/(dashboard)/[orgSlug]/purchases/__tests__/page-hex-purity.test.ts
@@ -1,0 +1,46 @@
+/**
+ * list-pages-pure-read sentinel (Group C): purchases/page.tsx MUST NOT import
+ * `@/lib/prisma` (zero direct Prisma reads — pure hexagonal page).
+ *
+ * The two direct batch hydrations (contact + fiscalPeriod `findMany` with
+ * `id IN (...)`) are dumb lookups that do NOT deserve new read ports
+ * (architect rule: reuse existing module services, no ceremony for a
+ * `<select>`). The page reuses the EXISTING `makeContactsService().list()`
+ * and `makeFiscalPeriodsService().list()` (same services the sale detail
+ * page consumes) and filters in-memory to the ids present in the current
+ * page-window, preserving the prior `id IN (...)` projection.
+ *
+ * RED expected failure mode (per [[red_acceptance_failure_mode]]): page.tsx
+ * imports `{ prisma } from "@/lib/prisma"` and invokes
+ * `prisma.contact.findMany` + `prisma.fiscalPeriod.findMany` → greps MUST be
+ * ZERO; FAILS pre-GREEN. GREEN: page consumes the contacts + fiscal-periods
+ * presentation server facades instead.
+ *
+ * Supersedes (flip documented in-place): c6a-cutover-null-guard-shape Test 7
+ * (`modules/purchase/presentation/__tests__/c6a-cutover-null-guard-shape.poc-nuevo-a3.test.ts`)
+ * which asserted the prisma import MUST be present (Prisma-direct batch lock).
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ROOT = resolve(__dirname, "..", "..", "..", "..", "..");
+const PAGE = resolve(ROOT, "app/(dashboard)/[orgSlug]/purchases/page.tsx");
+
+describe("list-pages-pure-read — /purchases list page hex purity", () => {
+  it("page.tsx does NOT import @/lib/prisma nor reference the prisma client", () => {
+    const src = readFileSync(PAGE, "utf8");
+    expect(src).not.toMatch(/@\/lib\/prisma/);
+    expect(src).not.toMatch(/\bprisma\./);
+  });
+
+  it("page.tsx consumes the existing contacts + fiscal-periods services (no new ports)", () => {
+    const src = readFileSync(PAGE, "utf8");
+    expect(src).toMatch(
+      /import\s*\{[^}]*\bmakeContactsService\b[^}]*\}\s*from\s*["']@\/modules\/contacts\/presentation\/server["']/,
+    );
+    expect(src).toMatch(
+      /import\s*\{[^}]*\bmakeFiscalPeriodsService\b[^}]*\}\s*from\s*["']@\/modules\/fiscal-periods\/presentation\/server["']/,
+    );
+  });
+});

--- a/app/(dashboard)/[orgSlug]/purchases/__tests__/page.test.ts
+++ b/app/(dashboard)/[orgSlug]/purchases/__tests__/page.test.ts
@@ -14,6 +14,12 @@
  * POC pagination-replication C1-MACRO Purchase: cascade adapt mismo batch
  * — `mockList` → `mockListPaginated` + searchParams Promise pass +
  * PaginatedResult shape mock (mirror Sale pilot precedent EXACT).
+ *
+ * Mocks updated list-pages-pure-read (Group C): `@/lib/prisma` mock stale
+ * post-purity cutover replaced by contacts + fiscal-periods presentation
+ * server facade mocks (`makeContactsService().list` /
+ * `makeFiscalPeriodsService().list` — mirror sales/[saleId] page-rbac
+ * precedent). Empty entity arrays preserve RBAC-only semantics.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
@@ -25,15 +31,15 @@ const {
   mockRequirePermission,
   mockMakePurchaseService,
   mockListPaginated,
-  mockContactFindMany,
-  mockPeriodFindMany,
+  mockContactsList,
+  mockPeriodsList,
 } = vi.hoisted(() => ({
   mockRedirect: vi.fn(),
   mockRequirePermission: vi.fn(),
   mockMakePurchaseService: vi.fn(),
   mockListPaginated: vi.fn(),
-  mockContactFindMany: vi.fn(),
-  mockPeriodFindMany: vi.fn(),
+  mockContactsList: vi.fn(),
+  mockPeriodsList: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({ redirect: mockRedirect }));
@@ -46,11 +52,12 @@ vi.mock("@/modules/purchase/presentation/composition-root", () => ({
   makePurchaseService: mockMakePurchaseService,
 }));
 
-vi.mock("@/lib/prisma", () => ({
-  prisma: {
-    contact: { findMany: mockContactFindMany },
-    fiscalPeriod: { findMany: mockPeriodFindMany },
-  },
+vi.mock("@/modules/contacts/presentation/server", () => ({
+  makeContactsService: vi.fn(() => ({ list: mockContactsList })),
+}));
+
+vi.mock("@/modules/fiscal-periods/presentation/server", () => ({
+  makeFiscalPeriodsService: vi.fn(() => ({ list: mockPeriodsList })),
 }));
 
 vi.mock("@/components/purchases/purchase-list", () => ({
@@ -79,8 +86,8 @@ beforeEach(() => {
     pageSize: 25,
     totalPages: 1,
   });
-  mockContactFindMany.mockResolvedValue([]);
-  mockPeriodFindMany.mockResolvedValue([]);
+  mockContactsList.mockResolvedValue([]);
+  mockPeriodsList.mockResolvedValue([]);
 });
 
 describe("/purchases — rbac gate", () => {

--- a/app/(dashboard)/[orgSlug]/purchases/page.tsx
+++ b/app/(dashboard)/[orgSlug]/purchases/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { requirePermission } from "@/modules/permissions/application/server";
-import { prisma } from "@/lib/prisma";
+import { makeContactsService } from "@/modules/contacts/presentation/server";
+import { makeFiscalPeriodsService } from "@/modules/fiscal-periods/presentation/server";
 import { makePurchaseService } from "@/modules/purchase/presentation/composition-root";
 import { toPurchaseWithDetails } from "@/modules/purchase/presentation/mappers/purchase-to-with-details.mapper";
 import { paginationQuerySchema } from "@/modules/shared/presentation/pagination.schema";
@@ -61,21 +62,33 @@ export default async function PurchasesPage({ params, searchParams }: PurchasesP
   const contactIds = [...new Set(purchases.map((p) => p.contactId))];
   const periodIds = [...new Set(purchases.map((p) => p.periodId))];
 
+  // Hex-pure batch hydration (list-pages-pure-read Group C): reuse the
+  // EXISTING contacts + fiscal-periods module services instead of direct
+  // Prisma `id IN (...)` reads — dumb lookups deserve no new read ports
+  // (architect rule; mirror sales/[saleId] detail page). Services return
+  // org-scoped entities; page filters in-memory to the ids in the current
+  // page-window, preserving the prior projection (inactive contacts and
+  // closed periods referenced by rows remain hydrated).
+  const contactsService = makeContactsService();
+  const periodsService = makeFiscalPeriodsService();
+  const contactIdSet = new Set(contactIds);
+  const periodIdSet = new Set(periodIds);
+
   const [contacts, periods] = await Promise.all([
-    prisma.contact.findMany({
-      where: { id: { in: contactIds } },
-      select: {
-        id: true,
-        name: true,
-        type: true,
-        nit: true,
-        paymentTermsDays: true,
-      },
-    }),
-    prisma.fiscalPeriod.findMany({
-      where: { id: { in: periodIds } },
-      select: { id: true, name: true, status: true },
-    }),
+    contactsService
+      .list(orgId)
+      .then((entities) =>
+        entities
+          .filter((c) => contactIdSet.has(c.id))
+          .map((c) => c.toSnapshot()),
+      ),
+    periodsService
+      .list(orgId)
+      .then((entities) =>
+        entities
+          .filter((p) => periodIdSet.has(p.id))
+          .map((p) => p.toSnapshot()),
+      ),
   ]);
 
   const contactMap = new Map(contacts.map((c) => [c.id, c]));

--- a/app/(dashboard)/[orgSlug]/sales/[saleId]/__tests__/page-hex-purity.test.ts
+++ b/app/(dashboard)/[orgSlug]/sales/[saleId]/__tests__/page-hex-purity.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Sale-pure-read pilot sentinel: sales/[saleId]/page.tsx MUST NOT import
+ * `@/lib/prisma` (zero direct Prisma reads — pure hexagonal page).
+ *
+ * The two direct reads (contact + receivable-with-allocations) moved behind
+ * sale-module read ports (`SaleContactReaderPort` / `SaleReceivableReaderPort`)
+ * with Prisma adapters in `modules/sale/infrastructure`, exposed via
+ * `makeSaleReads()` in the sale composition-root.
+ *
+ * RED expected failure mode (per [[red_acceptance_failure_mode]]): page.tsx
+ * imports `{ prisma } from "@/lib/prisma"` (L7) and invokes
+ * `prisma.contact.findUnique` + `prisma.accountsReceivable.findUnique`
+ * (L43-76) → greps MUST be ZERO; FAILS today. GREEN: page consumes
+ * `makeSaleReads()` instead.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ROOT = resolve(__dirname, "..", "..", "..", "..", "..", "..");
+const PAGE = resolve(ROOT, "app/(dashboard)/[orgSlug]/sales/[saleId]/page.tsx");
+
+describe("sale-pure-read pilot — sales/[saleId] hex purity", () => {
+  it("page.tsx does NOT import @/lib/prisma nor reference the prisma client", () => {
+    const src = readFileSync(PAGE, "utf8");
+    expect(src).not.toMatch(/@\/lib\/prisma/);
+    expect(src).not.toMatch(/\bprisma\./);
+  });
+
+  it("page.tsx consumes the sale read facade (makeSaleReads) from the composition-root", () => {
+    const src = readFileSync(PAGE, "utf8");
+    expect(src).toMatch(/\bmakeSaleReads\b/);
+  });
+});

--- a/app/(dashboard)/[orgSlug]/sales/[saleId]/__tests__/page-rbac.test.ts
+++ b/app/(dashboard)/[orgSlug]/sales/[saleId]/__tests__/page-rbac.test.ts
@@ -5,7 +5,11 @@
  *
  * Mocks updated A3-C4b cutover: legacy `@/features/sale/server` SaleService
  * replaced by hex `@/modules/sale/presentation/composition-root` makeSaleService
- * + Prisma direct deps lookups + `toSaleWithDetails` mapper invocation.
+ * + `toSaleWithDetails` mapper invocation.
+ *
+ * Sale-pure-read pilot: the two Prisma direct deps lookups (contact +
+ * receivable) moved behind `makeSaleReads()` read ports — the `@/lib/prisma`
+ * mock is gone; the composition-root mock now also stubs `makeSaleReads`.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
@@ -17,9 +21,10 @@ const {
   mockPeriodsList,
   mockAccountsList,
   mockMakeSaleService,
+  mockMakeSaleReads,
   mockToSaleWithDetails,
-  mockContactFindUnique,
-  mockReceivableFindUnique,
+  mockContactFindById,
+  mockReceivableFindWithAllocations,
 } = vi.hoisted(() => ({
   mockRedirect: vi.fn(),
   mockRequirePermission: vi.fn(),
@@ -28,9 +33,10 @@ const {
   mockPeriodsList: vi.fn(),
   mockAccountsList: vi.fn(),
   mockMakeSaleService: vi.fn(),
+  mockMakeSaleReads: vi.fn(),
   mockToSaleWithDetails: vi.fn(),
-  mockContactFindUnique: vi.fn(),
-  mockReceivableFindUnique: vi.fn(),
+  mockContactFindById: vi.fn(),
+  mockReceivableFindWithAllocations: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({ redirect: mockRedirect }));
@@ -41,17 +47,11 @@ vi.mock("@/modules/permissions/application/server", () => ({
 
 vi.mock("@/modules/sale/presentation/composition-root", () => ({
   makeSaleService: mockMakeSaleService,
+  makeSaleReads: mockMakeSaleReads,
 }));
 
 vi.mock("@/modules/sale/presentation/mappers/sale-to-with-details.mapper", () => ({
   toSaleWithDetails: mockToSaleWithDetails,
-}));
-
-vi.mock("@/lib/prisma", () => ({
-  prisma: {
-    contact: { findUnique: mockContactFindUnique },
-    accountsReceivable: { findUnique: mockReceivableFindUnique },
-  },
 }));
 
 vi.mock("@/modules/contacts/presentation/server", () => {
@@ -87,6 +87,10 @@ function makeParams() {
 beforeEach(() => {
   vi.clearAllMocks();
   mockMakeSaleService.mockReturnValue({ getById: mockSaleGetById });
+  mockMakeSaleReads.mockReturnValue({
+    contact: { findById: mockContactFindById },
+    receivable: { findWithAllocations: mockReceivableFindWithAllocations },
+  });
   mockSaleGetById.mockResolvedValue({
     id: SALE_ID,
     periodId: PERIOD_ID,
@@ -98,14 +102,14 @@ beforeEach(() => {
     { toSnapshot: () => ({ id: PERIOD_ID, name: "Test Period", status: "OPEN" }) },
   ]);
   mockAccountsList.mockResolvedValue([]);
-  mockContactFindUnique.mockResolvedValue({
+  mockContactFindById.mockResolvedValue({
     id: CONTACT_ID,
     name: "Test Contact",
     type: "CLIENTE",
     nit: null,
     paymentTermsDays: 30,
   });
-  mockReceivableFindUnique.mockResolvedValue(null);
+  mockReceivableFindWithAllocations.mockResolvedValue(null);
   mockToSaleWithDetails.mockReturnValue({});
 });
 

--- a/app/(dashboard)/[orgSlug]/sales/[saleId]/page.tsx
+++ b/app/(dashboard)/[orgSlug]/sales/[saleId]/page.tsx
@@ -4,8 +4,10 @@ import { makeContactsService } from "@/modules/contacts/presentation/server";
 import type { Contact } from "@/modules/contacts/presentation/index";
 import { makeFiscalPeriodsService } from "@/modules/fiscal-periods/presentation/server";
 import { makeAccountsService } from "@/modules/accounting/presentation/server";
-import { prisma } from "@/lib/prisma";
-import { makeSaleService } from "@/modules/sale/presentation/composition-root";
+import {
+  makeSaleReads,
+  makeSaleService,
+} from "@/modules/sale/presentation/composition-root";
 import { toSaleWithDetails } from "@/modules/sale/presentation/mappers/sale-to-with-details.mapper";
 import SaleForm from "@/components/sales/sale-form";
 
@@ -25,6 +27,7 @@ export default async function SaleDetailPage({ params }: SaleDetailPageProps) {
   }
 
   const saleService = makeSaleService();
+  const saleReads = makeSaleReads();
   const contactsService = makeContactsService();
   const periodsService = makeFiscalPeriodsService();
   const accountsService = makeAccountsService();
@@ -40,39 +43,9 @@ export default async function SaleDetailPage({ params }: SaleDetailPageProps) {
     contactsService.list(orgId, { type: "CLIENTE", isActive: true }).then((entities) => entities.map((c) => c.toSnapshot())),
     periodsService.list(orgId).then((entities) => entities.map((p) => p.toSnapshot())),
     accountsService.list(orgId, { type: "INGRESO", isDetail: true, isActive: true }),
-    prisma.contact.findUnique({
-      where: { id: sale.contactId },
-      select: {
-        id: true,
-        name: true,
-        type: true,
-        nit: true,
-        paymentTermsDays: true,
-      },
-    }),
+    saleReads.contact.findById(orgId, sale.contactId),
     sale.receivableId
-      ? prisma.accountsReceivable.findUnique({
-          where: { id: sale.receivableId },
-          select: {
-            id: true,
-            amount: true,
-            paid: true,
-            balance: true,
-            status: true,
-            dueDate: true,
-            allocations: {
-              select: {
-                id: true,
-                paymentId: true,
-                amount: true,
-                payment: {
-                  select: { id: true, date: true, description: true },
-                },
-              },
-              orderBy: { payment: { date: "asc" as const } },
-            },
-          },
-        })
+      ? saleReads.receivable.findWithAllocations(orgId, sale.receivableId)
       : Promise.resolve(null),
   ]);
 

--- a/app/(dashboard)/[orgSlug]/sales/__tests__/page-hex-purity.test.ts
+++ b/app/(dashboard)/[orgSlug]/sales/__tests__/page-hex-purity.test.ts
@@ -1,0 +1,46 @@
+/**
+ * list-pages-pure-read sentinel (Group C): sales/page.tsx MUST NOT import
+ * `@/lib/prisma` (zero direct Prisma reads — pure hexagonal page).
+ *
+ * The two direct batch hydrations (contact + fiscalPeriod `findMany` with
+ * `id IN (...)`) are dumb lookups that do NOT deserve new read ports
+ * (architect rule: reuse existing module services, no ceremony for a
+ * `<select>`). The page reuses the EXISTING `makeContactsService().list()`
+ * and `makeFiscalPeriodsService().list()` (same services the sale detail
+ * page consumes) and filters in-memory to the ids present in the current
+ * page-window, preserving the prior `id IN (...)` projection.
+ *
+ * RED expected failure mode (per [[red_acceptance_failure_mode]]): page.tsx
+ * imports `{ prisma } from "@/lib/prisma"` and invokes
+ * `prisma.contact.findMany` + `prisma.fiscalPeriod.findMany` → greps MUST be
+ * ZERO; FAILS pre-GREEN. GREEN: page consumes the contacts + fiscal-periods
+ * presentation server facades instead.
+ *
+ * Supersedes (flip documented in-place): c4a-cutover-shape Test 3
+ * (`modules/sale/presentation/__tests__/c4a-cutover-shape.poc-nuevo-a3.test.ts`)
+ * which asserted the prisma import MUST be present (Q4 Prisma-direct lock).
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ROOT = resolve(__dirname, "..", "..", "..", "..", "..");
+const PAGE = resolve(ROOT, "app/(dashboard)/[orgSlug]/sales/page.tsx");
+
+describe("list-pages-pure-read — /sales list page hex purity", () => {
+  it("page.tsx does NOT import @/lib/prisma nor reference the prisma client", () => {
+    const src = readFileSync(PAGE, "utf8");
+    expect(src).not.toMatch(/@\/lib\/prisma/);
+    expect(src).not.toMatch(/\bprisma\./);
+  });
+
+  it("page.tsx consumes the existing contacts + fiscal-periods services (no new ports)", () => {
+    const src = readFileSync(PAGE, "utf8");
+    expect(src).toMatch(
+      /import\s*\{[^}]*\bmakeContactsService\b[^}]*\}\s*from\s*["']@\/modules\/contacts\/presentation\/server["']/,
+    );
+    expect(src).toMatch(
+      /import\s*\{[^}]*\bmakeFiscalPeriodsService\b[^}]*\}\s*from\s*["']@\/modules\/fiscal-periods\/presentation\/server["']/,
+    );
+  });
+});

--- a/app/(dashboard)/[orgSlug]/sales/__tests__/page.test.ts
+++ b/app/(dashboard)/[orgSlug]/sales/__tests__/page.test.ts
@@ -11,6 +11,12 @@
  * page-rbac precedent (engram #1532). Test semantics RBAC-only preserved
  * (data path empty array — mapper never invoked).
  *
+ * Mocks updated list-pages-pure-read (Group C): `@/lib/prisma` mock stale
+ * post-purity cutover replaced by contacts + fiscal-periods presentation
+ * server facade mocks (`makeContactsService().list` /
+ * `makeFiscalPeriodsService().list` — mirror sales/[saleId] page-rbac
+ * precedent). Empty entity arrays preserve RBAC-only semantics.
+ *
  * C0 GREEN poc-dispatch-retirement-into-sales: dispatchService mock added
  * (twin-call cross-module read). RBAC semantics preserved — empty list
  * default keeps mapper paths shallow.
@@ -24,8 +30,8 @@ const {
   mockListPaginated,
   mockMakeDispatchService,
   mockDispatchListPaginated,
-  mockContactFindMany,
-  mockPeriodFindMany,
+  mockContactsList,
+  mockPeriodsList,
 } = vi.hoisted(() => ({
   mockRedirect: vi.fn(),
   mockRequirePermission: vi.fn(),
@@ -33,8 +39,8 @@ const {
   mockListPaginated: vi.fn(),
   mockMakeDispatchService: vi.fn(),
   mockDispatchListPaginated: vi.fn(),
-  mockContactFindMany: vi.fn(),
-  mockPeriodFindMany: vi.fn(),
+  mockContactsList: vi.fn(),
+  mockPeriodsList: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({ redirect: mockRedirect }));
@@ -51,11 +57,12 @@ vi.mock("@/modules/dispatch/presentation/composition-root", () => ({
   makeDispatchService: mockMakeDispatchService,
 }));
 
-vi.mock("@/lib/prisma", () => ({
-  prisma: {
-    contact: { findMany: mockContactFindMany },
-    fiscalPeriod: { findMany: mockPeriodFindMany },
-  },
+vi.mock("@/modules/contacts/presentation/server", () => ({
+  makeContactsService: vi.fn(() => ({ list: mockContactsList })),
+}));
+
+vi.mock("@/modules/fiscal-periods/presentation/server", () => ({
+  makeFiscalPeriodsService: vi.fn(() => ({ list: mockPeriodsList })),
 }));
 
 vi.mock("@/components/sales/transactions-list", () => ({
@@ -97,8 +104,8 @@ beforeEach(() => {
     pageSize: 25,
     totalPages: 1,
   });
-  mockContactFindMany.mockResolvedValue([]);
-  mockPeriodFindMany.mockResolvedValue([]);
+  mockContactsList.mockResolvedValue([]);
+  mockPeriodsList.mockResolvedValue([]);
 });
 
 describe("/sales — rbac gate", () => {

--- a/app/(dashboard)/[orgSlug]/sales/page.tsx
+++ b/app/(dashboard)/[orgSlug]/sales/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { requirePermission } from "@/modules/permissions/application/server";
-import { prisma } from "@/lib/prisma";
+import { makeContactsService } from "@/modules/contacts/presentation/server";
+import { makeFiscalPeriodsService } from "@/modules/fiscal-periods/presentation/server";
 import { makeSaleService } from "@/modules/sale/presentation/composition-root";
 import { toSaleWithDetails } from "@/modules/sale/presentation/mappers/sale-to-with-details.mapper";
 import { paginationQuerySchema } from "@/modules/shared/presentation/pagination.schema";
@@ -94,21 +95,33 @@ export default async function SalesPage({ params, searchParams }: SalesPageProps
     ]),
   ];
 
+  // Hex-pure batch hydration (list-pages-pure-read Group C): reuse the
+  // EXISTING contacts + fiscal-periods module services instead of direct
+  // Prisma `id IN (...)` reads — dumb lookups deserve no new read ports
+  // (architect rule; mirror sales/[saleId] detail page). Services return
+  // org-scoped entities; page filters in-memory to the ids in the current
+  // page-window, preserving the prior projection (inactive contacts and
+  // closed periods referenced by rows remain hydrated).
+  const contactsService = makeContactsService();
+  const periodsService = makeFiscalPeriodsService();
+  const contactIdSet = new Set(contactIds);
+  const periodIdSet = new Set(periodIds);
+
   const [contacts, periods] = await Promise.all([
-    prisma.contact.findMany({
-      where: { id: { in: contactIds } },
-      select: {
-        id: true,
-        name: true,
-        type: true,
-        nit: true,
-        paymentTermsDays: true,
-      },
-    }),
-    prisma.fiscalPeriod.findMany({
-      where: { id: { in: periodIds } },
-      select: { id: true, name: true, status: true },
-    }),
+    contactsService
+      .list(orgId)
+      .then((entities) =>
+        entities
+          .filter((c) => contactIdSet.has(c.id))
+          .map((c) => c.toSnapshot()),
+      ),
+    periodsService
+      .list(orgId)
+      .then((entities) =>
+        entities
+          .filter((p) => periodIdSet.has(p.id))
+          .map((p) => p.toSnapshot()),
+      ),
   ]);
 
   const contactMap = new Map(contacts.map((c) => [c.id, c]));

--- a/app/api/organizations/[orgSlug]/monthly-close/audit-trail/__tests__/route-hex-purity.test.ts
+++ b/app/api/organizations/[orgSlug]/monthly-close/audit-trail/__tests__/route-hex-purity.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Audit-pure-read (Group B) sentinel: monthly-close/audit-trail/route.ts MUST
+ * NOT import `@/lib/prisma` (zero direct Prisma reads — pure hexagonal route
+ * handler). The repo has no dedicated route-sentinel pattern, so this mirrors
+ * the page sentinel grep style of the sale-pure-read pilot
+ * (`app/(dashboard)/[orgSlug]/sales/[saleId]/__tests__/page-hex-purity.test.ts`).
+ *
+ * The direct close-event audit read (`prisma.auditLog.findMany` by
+ * correlationId) moved behind the audit-owned read port
+ * (`AuditCloseEventReaderPort`) with a Prisma adapter in
+ * `modules/audit/infrastructure`, exposed via `makeAuditReads()` in the audit
+ * composition-root.
+ *
+ * RED expected failure mode: route.ts imports `{ prisma } from "@/lib/prisma"`
+ * and invokes `prisma.auditLog.findMany` → greps MUST be ZERO; FAILS today.
+ * GREEN: route consumes `makeAuditReads()` instead.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ROOT = resolve(__dirname, "..", "..", "..", "..", "..", "..", "..");
+const ROUTE = resolve(
+  ROOT,
+  "app/api/organizations/[orgSlug]/monthly-close/audit-trail/route.ts",
+);
+
+describe("audit-pure-read Group B — audit-trail route hex purity", () => {
+  it("route.ts does NOT import @/lib/prisma nor reference the prisma client", () => {
+    const src = readFileSync(ROUTE, "utf8");
+    expect(src).not.toMatch(/@\/lib\/prisma/);
+    expect(src).not.toMatch(/\bprisma\./);
+  });
+
+  it("route.ts consumes the audit read facade (makeAuditReads) from the composition-root", () => {
+    const src = readFileSync(ROUTE, "utf8");
+    expect(src).toMatch(/\bmakeAuditReads\b/);
+  });
+});

--- a/app/api/organizations/[orgSlug]/monthly-close/audit-trail/__tests__/route.test.ts
+++ b/app/api/organizations/[orgSlug]/monthly-close/audit-trail/__tests__/route.test.ts
@@ -1,5 +1,5 @@
 /**
- * T59 — RED: Audit-trail route handler tests.
+ * T59 — Audit-trail route handler tests.
  *
  * GET /api/organizations/[orgSlug]/monthly-close/audit-trail?correlationId=<uuid>
  *
@@ -7,17 +7,23 @@
  * (a) Returns AuditLog[] filtered by correlationId.
  * (b) Returns 400 when correlationId is missing.
  * (c) Returns 403 when requirePermission throws ForbiddenError.
+ * (d) Gates on resource=period action=read.
  *
- * Fails until T60 creates the route.
+ * FLIPPED (audit-pure-read Group B): this test historically mocked
+ * `@/lib/prisma` and asserted `prisma.auditLog.findMany` was invoked by the
+ * route — i.e. it REQUIRED the route to import prisma directly. The read now
+ * lives behind the audit-owned `AuditCloseEventReaderPort` exposed via
+ * `makeAuditReads()`, so the test mocks the composition root instead and
+ * asserts the tenant-scoped port call `(orgId, correlationId)`.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 
-const { mockRequirePermission, mockFindMany } = vi.hoisted(() => ({
+const { mockRequirePermission, mockListByCorrelation } = vi.hoisted(() => ({
   mockRequirePermission: vi.fn(),
-  mockFindMany: vi.fn(),
+  mockListByCorrelation: vi.fn(),
 }));
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
@@ -26,12 +32,10 @@ vi.mock("@/modules/permissions/application/server", () => ({
   requirePermission: mockRequirePermission,
 }));
 
-vi.mock("@/lib/prisma", () => ({
-  prisma: {
-    auditLog: {
-      findMany: mockFindMany,
-    },
-  },
+vi.mock("@/modules/audit/presentation/server", () => ({
+  makeAuditReads: () => ({
+    closeEvents: { listByCorrelation: mockListByCorrelation },
+  }),
 }));
 
 vi.mock("@/modules/shared/presentation/middleware", () => ({
@@ -99,13 +103,13 @@ function makeRequest(correlationId?: string) {
 beforeEach(() => {
   vi.clearAllMocks();
   mockRequirePermission.mockResolvedValue({ orgId: ORG_ID });
-  mockFindMany.mockResolvedValue(auditRows);
+  mockListByCorrelation.mockResolvedValue(auditRows);
 });
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("GET /api/.../monthly-close/audit-trail", () => {
-  it("(a) returns AuditLog[] filtered by correlationId", async () => {
+  it("(a) returns AuditLog[] filtered by correlationId via the tenant-scoped audit read port", async () => {
     const res = await GET(makeRequest(CORRELATION_ID), { params: makeParams() });
 
     expect(res.status).toBe(200);
@@ -115,11 +119,8 @@ describe("GET /api/.../monthly-close/audit-trail", () => {
     expect(body[0].correlationId).toBe(CORRELATION_ID);
     expect(body[1].correlationId).toBe(CORRELATION_ID);
 
-    expect(mockFindMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({ correlationId: CORRELATION_ID }),
-      }),
-    );
+    expect(mockListByCorrelation).toHaveBeenCalledTimes(1);
+    expect(mockListByCorrelation).toHaveBeenCalledWith(ORG_ID, CORRELATION_ID);
   });
 
   it("(b) returns 400 when correlationId is missing", async () => {
@@ -128,6 +129,7 @@ describe("GET /api/.../monthly-close/audit-trail", () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.code).toBe("VALIDATION");
+    expect(mockListByCorrelation).not.toHaveBeenCalled();
   });
 
   it("(c) returns 403 when requirePermission throws ForbiddenError", async () => {

--- a/app/api/organizations/[orgSlug]/monthly-close/audit-trail/route.ts
+++ b/app/api/organizations/[orgSlug]/monthly-close/audit-trail/route.ts
@@ -1,6 +1,6 @@
 import { handleError } from "@/modules/shared/presentation/middleware";
 import { requirePermission } from "@/modules/permissions/application/server";
-import { prisma } from "@/lib/prisma";
+import { makeAuditReads } from "@/modules/audit/presentation/server";
 
 export async function GET(
   request: Request,
@@ -20,10 +20,13 @@ export async function GET(
       );
     }
 
-    const rows = await prisma.auditLog.findMany({
-      where: { organizationId: orgId, correlationId },
-      orderBy: [{ entityType: "asc" }, { createdAt: "asc" }],
-    });
+    // Registros del evento de cierre via tenant-scoped read port del módulo
+    // audit (audit-pure-read Group B). Ya llegan ordenados por entityType +
+    // createdAt.
+    const rows = await makeAuditReads().closeEvents.listByCorrelation(
+      orgId,
+      correlationId,
+    );
 
     return Response.json(rows);
   } catch (error) {

--- a/modules/audit/domain/ports/audit-close-event-reader.port.ts
+++ b/modules/audit/domain/ports/audit-close-event-reader.port.ts
@@ -1,0 +1,38 @@
+/**
+ * Read port for the audit rows of a single close/reopen event as consumed by
+ * the monthly-close close-event page and the monthly-close audit-trail API
+ * route (audit-pure-read Group B). Audit-hex declares this port instead of the
+ * consumers querying Prisma directly so the presentation layer stays decoupled
+ * from persistence (R2 §3 ports-only) and the read is tenant-scoped.
+ *
+ * The view is a clean DTO — plain values only, NO Prisma types (`Json?`
+ * columns arrive coerced to `Record<string, unknown> | null`, paridad
+ * `AuditRow`). The Prisma projection→view conversion lives in the
+ * infrastructure adapter (`PrismaAuditCloseEventReaderAdapter`).
+ */
+
+export interface AuditCloseEventView {
+  id: string;
+  organizationId: string;
+  entityType: string;
+  entityId: string;
+  action: string;
+  oldValues: Record<string, unknown> | null;
+  newValues: Record<string, unknown> | null;
+  changedById: string | null;
+  justification: string | null;
+  correlationId: string | null;
+  createdAt: Date;
+}
+
+export interface AuditCloseEventReaderPort {
+  /**
+   * Returns the audit rows emitted by a single close/reopen operation
+   * (grouped by `correlationId`), ordered by entityType then createdAt.
+   * Cross-tenant reads resolve to an empty list.
+   */
+  listByCorrelation(
+    organizationId: string,
+    correlationId: string,
+  ): Promise<AuditCloseEventView[]>;
+}

--- a/modules/audit/domain/ports/audit-org-members-reader.port.ts
+++ b/modules/audit/domain/ports/audit-org-members-reader.port.ts
@@ -1,0 +1,26 @@
+/**
+ * Read port for the active organization members shown in the audit page user
+ * filter select (audit-pure-read Group B). Owned by audit-hex because the read
+ * exists solely for audit display (changedBy filter options); it is NOT a
+ * general org-membership API. Declared here instead of the page querying
+ * Prisma directly so the presentation layer stays decoupled from persistence
+ * (R2 §3 ports-only) and the read is tenant-scoped.
+ *
+ * The view is a clean DTO — plain values only, NO Prisma types. The
+ * member→view mapping (`user.name ?? user.email` display fallback) lives in
+ * the infrastructure adapter (`PrismaAuditOrgMembersReaderAdapter`).
+ */
+
+export interface AuditOrgMemberView {
+  id: string;
+  name: string;
+}
+
+export interface AuditOrgMembersReaderPort {
+  /**
+   * Returns the active (non-deactivated) members of the organization as
+   * {id, name} options ordered by user name. Cross-tenant reads resolve to an
+   * empty list.
+   */
+  listActive(organizationId: string): Promise<AuditOrgMemberView[]>;
+}

--- a/modules/audit/infrastructure/__tests__/prisma-audit-close-event-reader.adapter.test.ts
+++ b/modules/audit/infrastructure/__tests__/prisma-audit-close-event-reader.adapter.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for PrismaAuditCloseEventReaderAdapter (audit-pure-read Group B).
+ *
+ * Mocks @/lib/prisma to avoid DB dependency — mirror
+ * `modules/sale/infrastructure/__tests__/prisma-sale-contact-reader.adapter.test.ts`
+ * mock pattern. Covers: query shape (tenant-scoped `findMany` where + orderBy),
+ * clean-view mapping (Json → Record, no Prisma types), and empty branch.
+ *
+ * RED acceptance failure mode: FAILS pre-implementación por module resolution
+ * failure (`PrismaAuditCloseEventReaderAdapter` no existe). Post-GREEN: PASSES
+ * porque el adapter emite el where {organizationId, correlationId} + orderBy
+ * [{entityType asc},{createdAt asc}] y retorna views planas.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    auditLog: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@/lib/prisma";
+import { PrismaAuditCloseEventReaderAdapter } from "../prisma-audit-close-event-reader.adapter";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const row = {
+  id: "audit-1",
+  organizationId: "org-1",
+  entityType: "fiscal_periods",
+  entityId: "period-1",
+  action: "STATUS_CHANGE",
+  oldValues: { status: "OPEN" },
+  newValues: { status: "CLOSED" },
+  changedById: null,
+  justification: null,
+  correlationId: "corr-1",
+  createdAt: new Date("2026-04-21T10:00:00.000Z"),
+};
+
+describe("PrismaAuditCloseEventReaderAdapter — listByCorrelation", () => {
+  it("scopes the query by organizationId AND correlationId (tenant safety) with entityType/createdAt ordering", async () => {
+    vi.mocked(prisma.auditLog.findMany).mockResolvedValueOnce([]);
+
+    const adapter = new PrismaAuditCloseEventReaderAdapter();
+    await adapter.listByCorrelation("org-1", "corr-1");
+
+    expect(prisma.auditLog.findMany).toHaveBeenCalledTimes(1);
+    expect(prisma.auditLog.findMany).toHaveBeenCalledWith({
+      where: { organizationId: "org-1", correlationId: "corr-1" },
+      orderBy: [{ entityType: "asc" }, { createdAt: "asc" }],
+      select: {
+        id: true,
+        organizationId: true,
+        entityType: true,
+        entityId: true,
+        action: true,
+        oldValues: true,
+        newValues: true,
+        changedById: true,
+        justification: true,
+        correlationId: true,
+        createdAt: true,
+      },
+    });
+  });
+
+  it("returns clean views (plain values, Json coerced to Record | null)", async () => {
+    vi.mocked(prisma.auditLog.findMany).mockResolvedValueOnce([row] as never);
+
+    const adapter = new PrismaAuditCloseEventReaderAdapter();
+    const result = await adapter.listByCorrelation("org-1", "corr-1");
+
+    expect(result).toEqual([
+      {
+        id: "audit-1",
+        organizationId: "org-1",
+        entityType: "fiscal_periods",
+        entityId: "period-1",
+        action: "STATUS_CHANGE",
+        oldValues: { status: "OPEN" },
+        newValues: { status: "CLOSED" },
+        changedById: null,
+        justification: null,
+        correlationId: "corr-1",
+        createdAt: new Date("2026-04-21T10:00:00.000Z"),
+      },
+    ]);
+  });
+
+  it("returns [] when no rows match organizationId + correlationId (cross-tenant or missing)", async () => {
+    vi.mocked(prisma.auditLog.findMany).mockResolvedValueOnce([]);
+
+    const adapter = new PrismaAuditCloseEventReaderAdapter();
+    const result = await adapter.listByCorrelation("org-other", "corr-1");
+
+    expect(result).toEqual([]);
+  });
+});

--- a/modules/audit/infrastructure/__tests__/prisma-audit-org-members-reader.adapter.test.ts
+++ b/modules/audit/infrastructure/__tests__/prisma-audit-org-members-reader.adapter.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit tests for PrismaAuditOrgMembersReaderAdapter (audit-pure-read Group B).
+ *
+ * Mocks @/lib/prisma to avoid DB dependency — mirror
+ * `modules/sale/infrastructure/__tests__/prisma-sale-contact-reader.adapter.test.ts`
+ * mock pattern. Covers: query shape (tenant-scoped `findMany` where active
+ * members + user projection + name ordering), name ?? email fallback mapping,
+ * and empty branch.
+ *
+ * RED acceptance failure mode: FAILS pre-implementación por module resolution
+ * failure (`PrismaAuditOrgMembersReaderAdapter` no existe). Post-GREEN: PASSES
+ * porque el adapter emite el where {organizationId, deactivatedAt: null} y
+ * mapea a views {id, name} con fallback a email.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    organizationMember: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@/lib/prisma";
+import { PrismaAuditOrgMembersReaderAdapter } from "../prisma-audit-org-members-reader.adapter";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PrismaAuditOrgMembersReaderAdapter — listActive", () => {
+  it("scopes the query by organizationId AND deactivatedAt null (tenant safety) ordered by user name", async () => {
+    vi.mocked(prisma.organizationMember.findMany).mockResolvedValueOnce([]);
+
+    const adapter = new PrismaAuditOrgMembersReaderAdapter();
+    await adapter.listActive("org-1");
+
+    expect(prisma.organizationMember.findMany).toHaveBeenCalledTimes(1);
+    expect(prisma.organizationMember.findMany).toHaveBeenCalledWith({
+      where: { organizationId: "org-1", deactivatedAt: null },
+      select: {
+        user: { select: { id: true, name: true, email: true } },
+      },
+      orderBy: { user: { name: "asc" } },
+    });
+  });
+
+  it("maps members to {id, name} views with email fallback when name is null", async () => {
+    vi.mocked(prisma.organizationMember.findMany).mockResolvedValueOnce([
+      { user: { id: "user-1", name: "Ana", email: "ana@acme.bo" } },
+      { user: { id: "user-2", name: null, email: "beto@acme.bo" } },
+    ] as never);
+
+    const adapter = new PrismaAuditOrgMembersReaderAdapter();
+    const result = await adapter.listActive("org-1");
+
+    expect(result).toEqual([
+      { id: "user-1", name: "Ana" },
+      { id: "user-2", name: "beto@acme.bo" },
+    ]);
+  });
+
+  it("returns [] when the organization has no active members", async () => {
+    vi.mocked(prisma.organizationMember.findMany).mockResolvedValueOnce([]);
+
+    const adapter = new PrismaAuditOrgMembersReaderAdapter();
+    const result = await adapter.listActive("org-other");
+
+    expect(result).toEqual([]);
+  });
+});

--- a/modules/audit/infrastructure/prisma-audit-close-event-reader.adapter.ts
+++ b/modules/audit/infrastructure/prisma-audit-close-event-reader.adapter.ts
@@ -1,0 +1,65 @@
+import "server-only";
+import type { PrismaClient } from "@/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+import type {
+  AuditCloseEventReaderPort,
+  AuditCloseEventView,
+} from "@/modules/audit/domain/ports/audit-close-event-reader.port";
+
+/**
+ * Prisma directo adapter for `AuditCloseEventReaderPort` (audit-pure-read
+ * Group B). Mirror the legacy close-event page / audit-trail route
+ * `prisma.auditLog.findMany` query, tenant-scoped with
+ * `{ organizationId, correlationId }` where (paridad
+ * `PrismaSaleContactReaderAdapter`) and explicit select projection so the
+ * view stays a clean DTO — `Json?` columns coerced to
+ * `Record<string, unknown> | null` (paridad `AuditRow`), no Prisma types leak.
+ *
+ * Constructor flexible: `db = prisma` default — paridad con
+ * `PrismaAuditRepository` / `PrismaUserNameResolver`.
+ */
+
+type DbClient = Pick<PrismaClient, "auditLog">;
+
+export class PrismaAuditCloseEventReaderAdapter
+  implements AuditCloseEventReaderPort
+{
+  constructor(private readonly db: DbClient = prisma) {}
+
+  async listByCorrelation(
+    organizationId: string,
+    correlationId: string,
+  ): Promise<AuditCloseEventView[]> {
+    const rows = await this.db.auditLog.findMany({
+      where: { organizationId, correlationId },
+      orderBy: [{ entityType: "asc" }, { createdAt: "asc" }],
+      select: {
+        id: true,
+        organizationId: true,
+        entityType: true,
+        entityId: true,
+        action: true,
+        oldValues: true,
+        newValues: true,
+        changedById: true,
+        justification: true,
+        correlationId: true,
+        createdAt: true,
+      },
+    });
+
+    return rows.map((row) => ({
+      id: row.id,
+      organizationId: row.organizationId,
+      entityType: row.entityType,
+      entityId: row.entityId,
+      action: row.action,
+      oldValues: (row.oldValues ?? null) as Record<string, unknown> | null,
+      newValues: (row.newValues ?? null) as Record<string, unknown> | null,
+      changedById: row.changedById,
+      justification: row.justification,
+      correlationId: row.correlationId,
+      createdAt: row.createdAt,
+    }));
+  }
+}

--- a/modules/audit/infrastructure/prisma-audit-org-members-reader.adapter.ts
+++ b/modules/audit/infrastructure/prisma-audit-org-members-reader.adapter.ts
@@ -1,0 +1,41 @@
+import "server-only";
+import type { PrismaClient } from "@/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+import type {
+  AuditOrgMembersReaderPort,
+  AuditOrgMemberView,
+} from "@/modules/audit/domain/ports/audit-org-members-reader.port";
+
+/**
+ * Prisma directo adapter for `AuditOrgMembersReaderPort` (audit-pure-read
+ * Group B). Mirror the legacy audit page `prisma.organizationMember.findMany`
+ * query — tenant-scoped `{ organizationId, deactivatedAt: null }` where — and
+ * absorb the `user.name ?? user.email` display fallback so the page receives
+ * clean `{id, name}` views (no Prisma types leak).
+ *
+ * Constructor flexible: `db = prisma` default — paridad con
+ * `PrismaAuditRepository` / `PrismaUserNameResolver`.
+ */
+
+type DbClient = Pick<PrismaClient, "organizationMember">;
+
+export class PrismaAuditOrgMembersReaderAdapter
+  implements AuditOrgMembersReaderPort
+{
+  constructor(private readonly db: DbClient = prisma) {}
+
+  async listActive(organizationId: string): Promise<AuditOrgMemberView[]> {
+    const members = await this.db.organizationMember.findMany({
+      where: { organizationId, deactivatedAt: null },
+      select: {
+        user: { select: { id: true, name: true, email: true } },
+      },
+      orderBy: { user: { name: "asc" } },
+    });
+
+    return members.map((m) => ({
+      id: m.user.id,
+      name: m.user.name ?? m.user.email,
+    }));
+  }
+}

--- a/modules/audit/presentation/composition-root.ts
+++ b/modules/audit/presentation/composition-root.ts
@@ -1,5 +1,9 @@
 import "server-only";
+import type { AuditCloseEventReaderPort } from "../domain/ports/audit-close-event-reader.port";
+import type { AuditOrgMembersReaderPort } from "../domain/ports/audit-org-members-reader.port";
 import { AuditService } from "../application/audit.service";
+import { PrismaAuditCloseEventReaderAdapter } from "../infrastructure/prisma-audit-close-event-reader.adapter";
+import { PrismaAuditOrgMembersReaderAdapter } from "../infrastructure/prisma-audit-org-members-reader.adapter";
 import { PrismaAuditRepository } from "../infrastructure/prisma-audit.repository";
 import { PrismaUserNameResolver } from "../infrastructure/prisma-user-name-resolver";
 
@@ -8,4 +12,24 @@ export function makeAuditService(): AuditService {
     new PrismaAuditRepository(),
     new PrismaUserNameResolver(),
   );
+}
+
+/**
+ * Read facade for audit external deps (audit-pure-read Group B) — groups the
+ * tenant-scoped read ports the audit page, the monthly-close close-event page
+ * and the monthly-close audit-trail route consume instead of querying Prisma
+ * directly. Wiring lives here (único archivo bajo `presentation/` autorizado a
+ * importar de `infrastructure/` — architecture.md R4 carve-out). Mirror
+ * `makeSaleReads()` in the sale composition-root (sale-pure-read pilot).
+ */
+export interface AuditReads {
+  closeEvents: AuditCloseEventReaderPort;
+  orgMembers: AuditOrgMembersReaderPort;
+}
+
+export function makeAuditReads(): AuditReads {
+  return {
+    closeEvents: new PrismaAuditCloseEventReaderAdapter(),
+    orgMembers: new PrismaAuditOrgMembersReaderAdapter(),
+  };
 }

--- a/modules/audit/presentation/server.ts
+++ b/modules/audit/presentation/server.ts
@@ -1,6 +1,10 @@
 import "server-only";
 
-export { makeAuditService } from "./composition-root";
+export {
+  makeAuditReads,
+  makeAuditService,
+  type AuditReads,
+} from "./composition-root";
 
 export {
   auditListQuerySchema,
@@ -38,3 +42,11 @@ export { AuditService, type UserNameResolver } from "../application/audit.servic
 export type { AuditRepository, AuditRow } from "../domain/audit.repository";
 export { classify, type ParentContext } from "../domain/audit.classifier";
 export type { AuditInquiryPort } from "../domain/ports/audit-inquiry.port";
+export type {
+  AuditCloseEventReaderPort,
+  AuditCloseEventView,
+} from "../domain/ports/audit-close-event-reader.port";
+export type {
+  AuditOrgMembersReaderPort,
+  AuditOrgMemberView,
+} from "../domain/ports/audit-org-members-reader.port";

--- a/modules/purchase/domain/ports/purchase-contact-reader.port.ts
+++ b/modules/purchase/domain/ports/purchase-contact-reader.port.ts
@@ -1,0 +1,31 @@
+/**
+ * Read port for the purchase's contact summary as consumed by the purchase
+ * detail page (purchase-pure-read — mirror sale-pure-read pilot).
+ * Purchase-hex declares this port instead of the page querying Prisma
+ * directly so the presentation layer stays decoupled from persistence
+ * (R2 §3 ports-only) and the read is tenant-scoped.
+ *
+ * The view is a clean DTO — plain values only, NO Prisma types. The Prisma
+ * projection→view conversion lives in the infrastructure adapter
+ * (`PrismaPurchaseContactReaderAdapter`).
+ */
+
+export interface PurchaseContactView {
+  id: string;
+  name: string;
+  type: string;
+  nit: string | null;
+  paymentTermsDays: number | null;
+}
+
+export interface PurchaseContactReaderPort {
+  /**
+   * Returns the contact summary for a purchase, or null when no contact
+   * matches the id within the organization (cross-tenant reads resolve to
+   * null).
+   */
+  findById(
+    organizationId: string,
+    contactId: string,
+  ): Promise<PurchaseContactView | null>;
+}

--- a/modules/purchase/domain/ports/purchase-payable-reader.port.ts
+++ b/modules/purchase/domain/ports/purchase-payable-reader.port.ts
@@ -1,0 +1,46 @@
+/**
+ * Read port for the purchase's payable-with-allocations as consumed by the
+ * purchase detail page (purchase-pure-read — mirror sale-pure-read pilot).
+ * Purchase-hex declares this port instead of the page querying Prisma
+ * directly so the presentation layer stays decoupled from persistence
+ * (R2 §3 ports-only) and the read is tenant-scoped.
+ *
+ * The view is a clean DTO — monetary fields are plain `number`, NO
+ * `Prisma.Decimal` leaks into the domain. The Decimal→number conversion is
+ * an infrastructure boundary concern (`PrismaPurchasePayableReaderAdapter`).
+ * Allocations arrive ordered by payment date ascending (adapter contract —
+ * mirrors the legacy page query `orderBy: { payment: { date: "asc" } }`).
+ */
+
+export interface PurchasePaymentAllocationView {
+  id: string;
+  paymentId: string;
+  amount: number;
+  payment: {
+    id: string;
+    date: Date;
+    description: string;
+  };
+}
+
+export interface PurchasePayableView {
+  id: string;
+  amount: number;
+  paid: number;
+  balance: number;
+  status: string;
+  dueDate: Date;
+  allocations: PurchasePaymentAllocationView[];
+}
+
+export interface PurchasePayableReaderPort {
+  /**
+   * Returns the payable with its payment allocations (ordered by payment
+   * date asc), or null when no payable matches the id within the
+   * organization (cross-tenant reads resolve to null).
+   */
+  findWithAllocations(
+    organizationId: string,
+    payableId: string,
+  ): Promise<PurchasePayableView | null>;
+}

--- a/modules/purchase/infrastructure/__tests__/prisma-purchase-contact-reader.adapter.test.ts
+++ b/modules/purchase/infrastructure/__tests__/prisma-purchase-contact-reader.adapter.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for PrismaPurchaseContactReaderAdapter (purchase-pure-read —
+ * mirror sale-pure-read pilot).
+ *
+ * Mocks @/lib/prisma to avoid DB dependency — mirror
+ * `modules/sale/infrastructure/__tests__/prisma-sale-contact-reader.adapter.test.ts`
+ * mock pattern. Covers: query shape (tenant-scoped `findFirst` where + select
+ * projection), clean-view passthrough, and null branch.
+ *
+ * RED acceptance failure mode: FAILS pre-implementación por module resolution
+ * failure (`PrismaPurchaseContactReaderAdapter` no existe). Post-GREEN: PASSES
+ * porque el adapter emite el where {id, organizationId} + select projection y
+ * retorna el row (shape ya limpio — no hay Decimal en la projection contact).
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    contact: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@/lib/prisma";
+import { PrismaPurchaseContactReaderAdapter } from "../prisma-purchase-contact-reader.adapter";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PrismaPurchaseContactReaderAdapter — findById", () => {
+  it("scopes the query by organizationId AND contact id (tenant safety) with the exact select projection", async () => {
+    vi.mocked(prisma.contact.findFirst).mockResolvedValueOnce(null);
+
+    const adapter = new PrismaPurchaseContactReaderAdapter();
+    await adapter.findById("org-1", "contact-1");
+
+    expect(prisma.contact.findFirst).toHaveBeenCalledTimes(1);
+    expect(prisma.contact.findFirst).toHaveBeenCalledWith({
+      where: { id: "contact-1", organizationId: "org-1" },
+      select: {
+        id: true,
+        name: true,
+        type: true,
+        nit: true,
+        paymentTermsDays: true,
+      },
+    });
+  });
+
+  it("returns the clean contact view when the row exists", async () => {
+    vi.mocked(prisma.contact.findFirst).mockResolvedValueOnce({
+      id: "contact-1",
+      name: "Proveedor Uno",
+      type: "PROVEEDOR",
+      nit: "12345-6",
+      paymentTermsDays: 30,
+      // Cast: mock returns the select projection, not the full Contact row.
+    } as never);
+
+    const adapter = new PrismaPurchaseContactReaderAdapter();
+    const result = await adapter.findById("org-1", "contact-1");
+
+    expect(result).toEqual({
+      id: "contact-1",
+      name: "Proveedor Uno",
+      type: "PROVEEDOR",
+      nit: "12345-6",
+      paymentTermsDays: 30,
+    });
+  });
+
+  it("returns null when no contact matches id + organizationId (cross-tenant or missing)", async () => {
+    vi.mocked(prisma.contact.findFirst).mockResolvedValueOnce(null);
+
+    const adapter = new PrismaPurchaseContactReaderAdapter();
+    const result = await adapter.findById("org-other", "contact-1");
+
+    expect(result).toBeNull();
+  });
+});

--- a/modules/purchase/infrastructure/__tests__/prisma-purchase-payable-reader.adapter.test.ts
+++ b/modules/purchase/infrastructure/__tests__/prisma-purchase-payable-reader.adapter.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for PrismaPurchasePayableReaderAdapter (purchase-pure-read —
+ * mirror sale-pure-read pilot).
+ *
+ * Mocks @/lib/prisma to avoid DB dependency — mirror
+ * `modules/sale/infrastructure/__tests__/prisma-sale-receivable-reader.adapter.test.ts`
+ * mock pattern. Covers: query shape (tenant-scoped `findFirst` where + nested
+ * allocations select ordered by payment.date asc), Decimal→number boundary
+ * conversion (port must NOT leak Prisma.Decimal), and null branch.
+ *
+ * Decimal mocking: `{ toNumber: () => n }` cast — same technique as the sale
+ * pilot fakeDecimal (no runtime Decimal value import).
+ *
+ * RED acceptance failure mode: FAILS pre-implementación por module resolution
+ * failure (`PrismaPurchasePayableReaderAdapter` no existe). Post-GREEN: PASSES
+ * porque el adapter emite el where {id, organizationId}, la projection nested
+ * con orderBy payment.date asc, y convierte amount/paid/balance/allocations
+ * amount de Decimal a number en el boundary infrastructure.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Prisma } from "@/generated/prisma/client";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    accountsPayable: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@/lib/prisma";
+import { PrismaPurchasePayableReaderAdapter } from "../prisma-purchase-payable-reader.adapter";
+
+const fakeDecimal = (n: number): Prisma.Decimal =>
+  ({ toNumber: () => n }) as unknown as Prisma.Decimal;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PrismaPurchasePayableReaderAdapter — findWithAllocations", () => {
+  it("scopes the query by organizationId AND payable id with nested allocations ordered by payment.date asc", async () => {
+    vi.mocked(prisma.accountsPayable.findFirst).mockResolvedValueOnce(null);
+
+    const adapter = new PrismaPurchasePayableReaderAdapter();
+    await adapter.findWithAllocations("org-1", "pay-1");
+
+    expect(prisma.accountsPayable.findFirst).toHaveBeenCalledTimes(1);
+    expect(prisma.accountsPayable.findFirst).toHaveBeenCalledWith({
+      where: { id: "pay-1", organizationId: "org-1" },
+      select: {
+        id: true,
+        amount: true,
+        paid: true,
+        balance: true,
+        status: true,
+        dueDate: true,
+        allocations: {
+          select: {
+            id: true,
+            paymentId: true,
+            amount: true,
+            payment: {
+              select: { id: true, date: true, description: true },
+            },
+          },
+          orderBy: { payment: { date: "asc" } },
+        },
+      },
+    });
+  });
+
+  it("converts Decimal fields (amount/paid/balance + allocation amounts) to plain numbers — no Prisma.Decimal leaks", async () => {
+    const paymentDate = new Date("2026-03-15T10:00:00Z");
+    vi.mocked(prisma.accountsPayable.findFirst).mockResolvedValueOnce({
+      id: "pay-1",
+      amount: fakeDecimal(150),
+      paid: fakeDecimal(50),
+      balance: fakeDecimal(100),
+      status: "PARTIAL",
+      dueDate: new Date("2026-04-30"),
+      allocations: [
+        {
+          id: "alloc-1",
+          paymentId: "pmt-1",
+          amount: fakeDecimal(50),
+          payment: {
+            id: "pmt-1",
+            date: paymentDate,
+            description: "Pago parcial",
+          },
+        },
+      ],
+      // Cast: mock returns the select projection, not the full row.
+    } as never);
+
+    const adapter = new PrismaPurchasePayableReaderAdapter();
+    const result = await adapter.findWithAllocations("org-1", "pay-1");
+
+    expect(result).toEqual({
+      id: "pay-1",
+      amount: 150,
+      paid: 50,
+      balance: 100,
+      status: "PARTIAL",
+      dueDate: new Date("2026-04-30"),
+      allocations: [
+        {
+          id: "alloc-1",
+          paymentId: "pmt-1",
+          amount: 50,
+          payment: {
+            id: "pmt-1",
+            date: paymentDate,
+            description: "Pago parcial",
+          },
+        },
+      ],
+    });
+    // Plain numbers, not Decimal-like objects.
+    expect(typeof result!.amount).toBe("number");
+    expect(typeof result!.allocations[0].amount).toBe("number");
+  });
+
+  it("returns null when no payable matches id + organizationId (cross-tenant or missing)", async () => {
+    vi.mocked(prisma.accountsPayable.findFirst).mockResolvedValueOnce(null);
+
+    const adapter = new PrismaPurchasePayableReaderAdapter();
+    const result = await adapter.findWithAllocations("org-other", "pay-1");
+
+    expect(result).toBeNull();
+  });
+});

--- a/modules/purchase/infrastructure/prisma-purchase-contact-reader.adapter.ts
+++ b/modules/purchase/infrastructure/prisma-purchase-contact-reader.adapter.ts
@@ -1,0 +1,43 @@
+import "server-only";
+import type { PrismaClient } from "@/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+import type {
+  PurchaseContactReaderPort,
+  PurchaseContactView,
+} from "@/modules/purchase/domain/ports/purchase-contact-reader.port";
+
+/**
+ * Prisma directo adapter for `PurchaseContactReaderPort` (purchase-pure-read
+ * — mirror sale-pure-read pilot). Mirror the legacy purchases/[purchaseId]
+ * page `prisma.contact.findUnique` select projection, upgraded to `findFirst`
+ * with `{ id, organizationId }` where for tenant scoping (paridad
+ * `PrismaPurchaseRepository.findById`).
+ *
+ * Constructor flexible: `db = prisma` default — paridad con
+ * `PrismaPurchaseRepository`.
+ */
+
+type DbClient = Pick<PrismaClient, "contact">;
+
+export class PrismaPurchaseContactReaderAdapter
+  implements PurchaseContactReaderPort
+{
+  constructor(private readonly db: DbClient = prisma) {}
+
+  async findById(
+    organizationId: string,
+    contactId: string,
+  ): Promise<PurchaseContactView | null> {
+    const row = await this.db.contact.findFirst({
+      where: { id: contactId, organizationId },
+      select: {
+        id: true,
+        name: true,
+        type: true,
+        nit: true,
+        paymentTermsDays: true,
+      },
+    });
+    return row;
+  }
+}

--- a/modules/purchase/infrastructure/prisma-purchase-payable-reader.adapter.ts
+++ b/modules/purchase/infrastructure/prisma-purchase-payable-reader.adapter.ts
@@ -1,0 +1,77 @@
+import "server-only";
+import type { PrismaClient } from "@/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+import type {
+  PurchasePayableReaderPort,
+  PurchasePayableView,
+} from "@/modules/purchase/domain/ports/purchase-payable-reader.port";
+
+/**
+ * Prisma directo adapter for `PurchasePayableReaderPort` (purchase-pure-read
+ * — mirror sale-pure-read pilot). Mirror the legacy purchases/[purchaseId]
+ * page `prisma.accountsPayable.findUnique` select projection (nested
+ * allocations + payment ordered by payment.date asc), upgraded to `findFirst`
+ * with `{ id, organizationId }` where for tenant scoping (paridad
+ * `PrismaPurchaseRepository.findById`).
+ *
+ * Decimal→number conversion happens HERE (infrastructure boundary) so the
+ * port view never leaks `Prisma.Decimal` into domain/presentation.
+ *
+ * Constructor flexible: `db = prisma` default — paridad con
+ * `PrismaPurchaseRepository`.
+ */
+
+type DbClient = Pick<PrismaClient, "accountsPayable">;
+
+export class PrismaPurchasePayableReaderAdapter
+  implements PurchasePayableReaderPort
+{
+  constructor(private readonly db: DbClient = prisma) {}
+
+  async findWithAllocations(
+    organizationId: string,
+    payableId: string,
+  ): Promise<PurchasePayableView | null> {
+    const row = await this.db.accountsPayable.findFirst({
+      where: { id: payableId, organizationId },
+      select: {
+        id: true,
+        amount: true,
+        paid: true,
+        balance: true,
+        status: true,
+        dueDate: true,
+        allocations: {
+          select: {
+            id: true,
+            paymentId: true,
+            amount: true,
+            payment: {
+              select: { id: true, date: true, description: true },
+            },
+          },
+          orderBy: { payment: { date: "asc" as const } },
+        },
+      },
+    });
+    if (!row) return null;
+    return {
+      id: row.id,
+      amount: row.amount.toNumber(),
+      paid: row.paid.toNumber(),
+      balance: row.balance.toNumber(),
+      status: row.status,
+      dueDate: row.dueDate,
+      allocations: row.allocations.map((allocation) => ({
+        id: allocation.id,
+        paymentId: allocation.paymentId,
+        amount: allocation.amount.toNumber(),
+        payment: {
+          id: allocation.payment.id,
+          date: allocation.payment.date,
+          description: allocation.payment.description,
+        },
+      })),
+    };
+  }
+}

--- a/modules/purchase/presentation/__tests__/c6a-cutover-null-guard-shape.poc-nuevo-a3.test.ts
+++ b/modules/purchase/presentation/__tests__/c6a-cutover-null-guard-shape.poc-nuevo-a3.test.ts
@@ -104,10 +104,15 @@ describe("A3-C6a purchase list cutover + null guard shape — post-retirement su
     );
   });
 
-  it("Test 7: page imports prisma from @/lib/prisma (Prisma direct batch lookups)", () => {
-    expect(pageSource).toMatch(
-      /import\s*\{[^}]*\bprisma\b[^}]*\}\s*from\s*["']@\/lib\/prisma["']/,
-    );
+  // Test 7 FLIPPED (list-pages-pure-read Group C): original assertion locked
+  // the Prisma-direct batch-lookup pattern (`prisma` import PRESENT, mirror
+  // A3-C4a Q4). That lock is SUPERSEDED — the batch hydrations moved behind
+  // the EXISTING contacts + fiscal-periods module services (no new read
+  // ports; architect rule: reuse, no ceremony for dumb lookups). Assertion
+  // inverted: prisma import must now be ABSENT. Positive counterpart lives in
+  // app/(dashboard)/[orgSlug]/purchases/__tests__/page-hex-purity.test.ts.
+  it("Test 7 (flipped): page does NOT import prisma from @/lib/prisma (list-pages-pure-read supersedes Prisma-direct lock)", () => {
+    expect(pageSource).not.toMatch(/["']@\/lib\/prisma["']/);
   });
 
   // Tests 8-10 (page imports TYPE_PREFIXES + computeDisplayCode + null guard

--- a/modules/purchase/presentation/__tests__/c6b-cutover-null-guard-shape.poc-nuevo-a3.test.ts
+++ b/modules/purchase/presentation/__tests__/c6b-cutover-null-guard-shape.poc-nuevo-a3.test.ts
@@ -65,6 +65,18 @@
  * (sequenceNumber=null) branch coverage requerido caller responsibility null
  * guard ternary mirror §13.AC HubService A3-C5 SubQ-β.
  *
+ * SUPERSEDED (purchase-pure-read — mirror sale-pure-read pilot c4b flip):
+ * el lock original (Prisma direct deps lookups en page) fue reemplazado —
+ * los 2 reads (contact + payable+allocations) viven detrás de read ports del
+ * purchase module (`PurchaseContactReaderPort` / `PurchasePayableReaderPort`)
+ * expuestos via `makePurchaseReads()`. Test 4 flipped: ahora asserta
+ * `makePurchaseReads` import PRESENT + `@/lib/prisma` import ABSENT (page
+ * pure hexagonal). Test 5 flipped: `prisma.accountsPayable.findUnique`
+ * ABSENT — el lookup vive en `PrismaPurchasePayableReaderAdapter`
+ * (tenant-scoped findFirst). Ver
+ * `app/(dashboard)/[orgSlug]/purchases/[purchaseId]/__tests__/page-hex-purity.test.ts`
+ * (sentinel dedicado).
+ *
  * Expected RED failure mode (verify pre-GREEN):
  * - 9 positive FAIL: page imports makePurchaseService + toPurchaseWithDetails +
  *   TYPE_PREFIXES/computeDisplayCode + prisma + Prisma direct accountsPayable
@@ -109,16 +121,17 @@ describe("A3-C6b RED purchase detail cutover + null guard shape — combined axe
   // REQ-DISPLAY-2 derivative (T4.5 SHAPE-LOCK Group C). Page-side helpers
   // wholesale-deleted in T2.5-page/T4.3.
 
-  it("Test 4: page imports prisma from @/lib/prisma (Prisma direct lookups)", () => {
+  it("Test 4: page imports `makePurchaseReads` (read ports) and does NOT import `@/lib/prisma` (purchase-pure-read supersedes Prisma direct lock)", () => {
     expect(pageSource).toMatch(
-      /import\s*\{[^}]*\bprisma\b[^}]*\}\s*from\s*["']@\/lib\/prisma["']/,
+      /import\s*\{[^}]*\bmakePurchaseReads\b[^}]*\}\s*from\s*["']@\/modules\/purchase\/presentation\/composition-root["']/,
     );
+    expect(pageSource).not.toMatch(/["']@\/lib\/prisma["']/);
   });
 
-  // ── Page Prisma direct lookups + invocation positive (3 mirror A3-C4b.5) ────
+  // ── Page read-port lookups + invocation positive (mirror A3-C4b.5 flipped) ──
 
-  it("Test 5: page contains prisma.accountsPayable.findUnique (Prisma direct payable conditional lookup)", () => {
-    expect(pageSource).toMatch(/prisma\.accountsPayable\.findUnique/);
+  it("Test 5: page does NOT contain prisma.accountsPayable.findUnique (payable lookup lives behind PurchasePayableReaderPort)", () => {
+    expect(pageSource).not.toMatch(/prisma\.accountsPayable\.findUnique/);
   });
 
   // Test 6 RETIRED (lcv-feature-retirement L3): ivaPurchaseBook.findUnique removed

--- a/modules/purchase/presentation/composition-root.ts
+++ b/modules/purchase/presentation/composition-root.ts
@@ -13,9 +13,13 @@ import { PrismaOperationalDocTypesRepository } from "@/modules/operational-doc-t
 import { makePayablesRepository } from "@/modules/payables/presentation/server";
 import type { UnitOfWorkRepoLike } from "@/modules/shared/infrastructure/prisma-unit-of-work";
 
+import type { PurchaseContactReaderPort } from "../domain/ports/purchase-contact-reader.port";
+import type { PurchasePayableReaderPort } from "../domain/ports/purchase-payable-reader.port";
 import { PurchaseService } from "../application/purchase.service";
 import { LegacyPurchasePermissionsAdapter } from "../infrastructure/legacy-purchase-permissions.adapter";
 import { PrismaOrgSettingsReaderAdapter } from "../infrastructure/prisma-org-settings-reader.adapter";
+import { PrismaPurchaseContactReaderAdapter } from "../infrastructure/prisma-purchase-contact-reader.adapter";
+import { PrismaPurchasePayableReaderAdapter } from "../infrastructure/prisma-purchase-payable-reader.adapter";
 import { PrismaPurchaseRepository } from "../infrastructure/prisma-purchase.repository";
 import { PrismaPurchaseUnitOfWork } from "../infrastructure/prisma-purchase-unit-of-work";
 
@@ -52,6 +56,25 @@ const accountLookupAdapter = new LegacyAccountLookupAdapter(accountsRepo);
 // journal-physical-document Phase 6 — OperationalDocType lookup repo for the
 // purchase UoW factory wiring (resolves FL|PF|CG|SV via findByCode).
 const operationalDocTypesRepo = new PrismaOperationalDocTypesRepository();
+
+/**
+ * Read facade for purchase detail page external deps (purchase-pure-read —
+ * mirror sale-pure-read pilot) — groups the tenant-scoped read ports the page
+ * consumes instead of querying Prisma directly. Wiring lives here (único
+ * archivo bajo `presentation/` autorizado a importar de `infrastructure/` —
+ * architecture.md R4 carve-out).
+ */
+export interface PurchaseReads {
+  contact: PurchaseContactReaderPort;
+  payable: PurchasePayableReaderPort;
+}
+
+export function makePurchaseReads(): PurchaseReads {
+  return {
+    contact: new PrismaPurchaseContactReaderAdapter(),
+    payable: new PrismaPurchasePayableReaderAdapter(),
+  };
+}
 
 export function makePurchaseService(): PurchaseService {
   return new PurchaseService({

--- a/modules/purchase/presentation/mappers/__tests__/purchase-to-with-details.mapper.test.ts
+++ b/modules/purchase/presentation/mappers/__tests__/purchase-to-with-details.mapper.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+
+import { Purchase } from "@/modules/purchase/domain/purchase.entity";
+import { PurchaseDetail } from "@/modules/purchase/domain/purchase-detail.entity";
+import { MonetaryAmount } from "@/modules/shared/domain/value-objects/monetary-amount";
+
+import {
+  toContactSummary,
+  toPayableSummary,
+  toPeriodSummary,
+  toPurchaseDetailRow,
+  toPurchaseWithDetails,
+} from "../purchase-to-with-details.mapper";
+
+/**
+ * Smoke type-check + runtime behavior para mappers presentation Purchase
+ * (purchase-pure-read — mirror sale-pure-read pilot
+ * `sale-to-with-details.mapper.test.ts`).
+ *
+ * Purchase-pure-read: deps ya NO llegan como Prisma raw con Decimal — el
+ * caller (page) los carga via read ports (`PurchaseContactReaderPort` /
+ * `PurchasePayableReaderPort`) cuyos adapters convierten Decimal→number en el
+ * boundary infrastructure. El mapper consume shapes limpios (numbers) y NO
+ * importa Prisma ni siquiera type-only.
+ *
+ * RED acceptance failure mode: FAILS pre-refactor porque `toPayableSummary`
+ * invoca `.toNumber()` sobre los montos (espera Prisma.Decimal) → TypeError
+ * al recibir plain numbers. Post-GREEN: PASSES porque el mapper hace
+ * passthrough de numbers limpios (Decimal→number ya ocurrió en el adapter).
+ */
+
+describe("purchase-to-with-details mappers (smoke)", () => {
+  // ── Test 1: toContactSummary passthrough ──────────────────────────────────────
+
+  it("toContactSummary passthrough clean view → DTO contact shape", () => {
+    const contact = {
+      id: "c-1",
+      name: "Proveedor Uno",
+      type: "PROVEEDOR",
+      nit: "12345-6",
+      paymentTermsDays: 30,
+    };
+    const result = toContactSummary(contact);
+    expect(result).toEqual(contact);
+    expect(result.nit).toBe("12345-6");
+    expect(result.paymentTermsDays).toBe(30);
+  });
+
+  // ── Test 2: toPeriodSummary passthrough ───────────────────────────────────────
+
+  it("toPeriodSummary passthrough clean view → DTO period shape", () => {
+    const period = { id: "p-1", name: "Enero 2026", status: "OPEN" };
+    expect(toPeriodSummary(period)).toEqual(period);
+  });
+
+  // ── Test 3: toPayableSummary clean numbers + nested allocations ───────────────
+
+  it("toPayableSummary clean numbers passthrough + nested allocations + payment.date toISOString", () => {
+    const paymentDate = new Date("2026-03-15T10:00:00Z");
+    const payable = {
+      id: "pay-1",
+      amount: 150,
+      paid: 50,
+      balance: 100,
+      status: "PARTIAL",
+      dueDate: new Date("2026-04-30"),
+      allocations: [
+        {
+          id: "a-1",
+          paymentId: "pmt-1",
+          amount: 50,
+          payment: {
+            id: "pmt-1",
+            date: paymentDate,
+            description: "Pago parcial",
+          },
+        },
+      ],
+    };
+    const result = toPayableSummary(payable);
+    expect(result.id).toBe("pay-1");
+    expect(result.amount).toBe(150);
+    expect(result.paid).toBe(50);
+    expect(result.balance).toBe(100);
+    expect(result.status).toBe("PARTIAL");
+    expect(result.allocations).toHaveLength(1);
+    expect(result.allocations[0].amount).toBe(50);
+    expect(result.allocations[0].payment.date).toBe(paymentDate.toISOString());
+  });
+
+  // ── Test 4: toPurchaseDetailRow MonetaryAmount→number conversion ──────────────
+
+  it("toPurchaseDetailRow MonetaryAmount→number + optional fields undefined→null", () => {
+    const detail = PurchaseDetail.fromPersistence({
+      id: "d-1",
+      purchaseId: "pu-1",
+      description: "Línea uno",
+      lineAmount: MonetaryAmount.of(99.5),
+      order: 0,
+      quantity: undefined,
+      unitPrice: undefined,
+      expenseAccountId: "acc-1",
+    });
+    const row = toPurchaseDetailRow(detail);
+    expect(row.id).toBe("d-1");
+    expect(row.purchaseId).toBe("pu-1");
+    expect(row.description).toBe("Línea uno");
+    expect(row.lineAmount).toBe(99.5);
+    expect(row.quantity).toBeNull();
+    expect(row.unitPrice).toBeNull();
+    expect(row.grossWeight).toBeNull();
+    expect(row.realNetWeight).toBeNull();
+    expect(row.order).toBe(0);
+    expect(row.expenseAccountId).toBe("acc-1");
+  });
+
+  // ── Test 5: toPurchaseWithDetails main compositor end-to-end ──────────────────
+
+  it("toPurchaseWithDetails main compositor caller-passes-deps Purchase entity + deps → PurchaseWithDetails", () => {
+    const detail = PurchaseDetail.fromPersistence({
+      id: "d-1",
+      purchaseId: "pu-1",
+      description: "Línea uno",
+      lineAmount: MonetaryAmount.of(100),
+      order: 0,
+      quantity: 2,
+      unitPrice: 50,
+      expenseAccountId: "acc-1",
+    });
+    const purchase = Purchase.fromPersistence({
+      id: "pu-1",
+      organizationId: "org-1",
+      purchaseType: "COMPRA_GENERAL",
+      status: "POSTED",
+      sequenceNumber: 7,
+      date: new Date("2026-03-01"),
+      contactId: "c-1",
+      periodId: "p-1",
+      description: "Compra de prueba",
+      referenceNumber: 100,
+      notes: null,
+      totalAmount: MonetaryAmount.of(100),
+      ruta: null,
+      farmOrigin: null,
+      chickenCount: null,
+      shrinkagePct: null,
+      totalGrossKg: null,
+      totalNetKg: null,
+      totalShrinkKg: null,
+      totalShortageKg: null,
+      totalRealNetKg: null,
+      journalEntryId: "j-1",
+      payableId: "pay-1",
+      createdById: "u-1",
+      createdAt: new Date("2026-03-01"),
+      updatedAt: new Date("2026-03-01"),
+      details: [detail],
+      payable: null,
+    });
+    const deps = {
+      contact: {
+        id: "c-1",
+        name: "Proveedor Uno",
+        type: "PROVEEDOR",
+        nit: null,
+        paymentTermsDays: null,
+      },
+      period: { id: "p-1", name: "Marzo 2026", status: "OPEN" },
+    };
+    const result = toPurchaseWithDetails(purchase, deps);
+    expect(result.id).toBe("pu-1");
+    expect(result.organizationId).toBe("org-1");
+    expect(result.purchaseType).toBe("COMPRA_GENERAL");
+    expect(result.status).toBe("POSTED");
+    expect(result.sequenceNumber).toBe(7);
+    expect(result.totalAmount).toBe(100);
+    expect(result.contact.name).toBe("Proveedor Uno");
+    expect(result.period.name).toBe("Marzo 2026");
+    expect(result.createdById).toBe("u-1");
+    expect(result.details).toHaveLength(1);
+    expect(result.details[0].lineAmount).toBe(100);
+    expect(result.details[0].quantity).toBe(2);
+    expect(result.payable).toBeNull();
+  });
+});

--- a/modules/purchase/presentation/mappers/purchase-to-with-details.mapper.ts
+++ b/modules/purchase/presentation/mappers/purchase-to-with-details.mapper.ts
@@ -1,7 +1,5 @@
 import "server-only";
 
-import type { Prisma } from "@/generated/prisma/client";
-
 import type { Purchase } from "../../domain/purchase.entity";
 import type { PurchaseDetail } from "../../domain/purchase-detail.entity";
 import type {
@@ -22,17 +20,17 @@ import type {
  * pre A3-C6 cutover 4 callers (page list lean + page detail Prisma direct
  * payable+ivaPurchaseBook + routes 3+4 atomic interdependence).
  *
- * Pattern: caller (page/route) loads external deps via separate Prisma
- * queries (contact via Prisma direct, period via reuse periods list o Prisma
- * direct, payable via Prisma direct §13.X-purchase, ivaPurchaseBook via
- * Prisma direct mirror A3-C4b sale precedent) y pasa al main compositor
+ * Pattern: caller (page/route) loads external deps via services/read ports
+ * (contact + payable via `makePurchaseReads()` purchase read ports, period
+ * via reuse periods list) y pasa al main compositor
  * `toPurchaseWithDetails(purchase, deps)` que invoca sub-mappers cohesivos.
  *
  * Hex purity preserved: mapper consume Purchase domain entity output
  * (`makePurchaseService`), NO toca presentation concerns dentro de
  * application layer. Sub-mappers EXTERNAL deps (contact/period/payable)
- * reciben Prisma raw shape passthrough (Marco Q-final-4 lock — caller ya
- * carga via Prisma queries, mapper recibe directo).
+ * reciben clean views desde los read ports (purchase-pure-read — mirror
+ * sale-pure-read pilot: los adapters Prisma convierten Decimal→number en el
+ * boundary infrastructure, mapper recibe numbers).
  *
  * §13.W-purchase resolution (A3-C5.5 atomic paired este ciclo): unused
  * user-summary nested field dropeado del mapper deps signature + DTO. Verified
@@ -49,14 +47,14 @@ import type {
  * null` per PurchaseDetailRow `number | null` shape (Prisma optional fields
  * llegan como `T | null` en DTO; hex entity getters como `T | undefined`).
  *
- * R5 banPrismaInPresentation preserved via type-only Prisma import (A3-C1.5
- * §13.V carve-out allowTypeImports: true). NO runtime Prisma value usage en
- * mapper module — Decimal.toNumber() invocado sobre instance ya construida
- * upstream por Prisma query (caller-side).
+ * R5 banPrismaInPresentation preserved — purchase-pure-read removed even the
+ * type-only Prisma import (mirror sale-pure-read pilot): deps arrive as clean
+ * views (plain numbers) from the purchase read ports, so no `Prisma.Decimal`
+ * appears anywhere in this module.
  *
  * Asimetría purchase vs sale precedent (mirror estructura, different concept):
  *   - sale `toReceivableSummary` ↔ purchase `toPayableSummary` (cuentas por
- *     cobrar vs pagar — Prisma raw → DTO Decimal→number + nested allocations)
+ *     cobrar vs pagar — clean numbers passthrough + nested allocations)
  *   - sale fixed prefix `VG` ↔ purchase TYPE_PREFIXES `FL/PF/CG/SV` per
  *     `PurchaseType` (4 polymorphic discriminators)
  *   - sale `toSaleDetailRow` 5 fields ↔ purchase `toPurchaseDetailRow` 12+
@@ -75,15 +73,17 @@ import type {
  * - modules/sale/presentation/mappers/sale-to-with-details.mapper.ts (229 LOC simétrico precedent)
  */
 
-// ── Types: Prisma raw shapes mirror legacy `purchaseInclude` ──────────────────
+// ── Types: clean external dep views (mirror legacy `purchaseInclude` fields) ──
 //
 // External dep input shapes corresponden 1:1 a legacy `purchaseInclude` /
-// `purchaseDetailInclude` Prisma select projections (legacy
-// purchaseInclude+purchaseDetailInclude — post-A3-C8 atomic delete commit 4aa8480).
-// Caller carga estos shapes via Prisma queries (typically con `select`
-// matching estos fields).
+// `purchaseDetailInclude` select projections (post-A3-C8 atomic delete commit
+// 4aa8480) PERO ya limpios: monetary fields son `number` (purchase-pure-read
+// — caller carga via `makePurchaseReads()` read ports cuyos adapters
+// convierten Decimal→number en infrastructure). Structural typing:
+// `PurchaseContactView` / `PurchasePayableView` (domain ports) satisfacen
+// estos shapes sin acoplar el mapper a los ports.
 
-export type ContactRaw = {
+export type ContactView = {
   id: string;
   name: string;
   type: string;
@@ -91,16 +91,16 @@ export type ContactRaw = {
   paymentTermsDays?: number | null;
 };
 
-export type PeriodRaw = {
+export type PeriodView = {
   id: string;
   name: string;
   status: string;
 };
 
-export type AllocationRaw = {
+export type AllocationView = {
   id: string;
   paymentId: string;
-  amount: Prisma.Decimal;
+  amount: number;
   payment: {
     id: string;
     date: Date;
@@ -108,28 +108,28 @@ export type AllocationRaw = {
   };
 };
 
-export type PayableRaw = {
+export type PayableView = {
   id: string;
-  amount: Prisma.Decimal;
-  paid: Prisma.Decimal;
-  balance: Prisma.Decimal;
+  amount: number;
+  paid: number;
+  balance: number;
   status: string;
   dueDate: Date;
-  allocations: AllocationRaw[];
+  allocations: AllocationView[];
 };
 
 // ── Main mapper deps (caller-passes-deps signature) ───────────────────────────
 
 export interface ToPurchaseWithDetailsDeps {
-  contact: ContactRaw;
-  period: PeriodRaw;
-  payable?: PayableRaw | null;
+  contact: ContactView;
+  period: PeriodView;
+  payable?: PayableView | null;
 }
 
-// ── Sub-mappers: passthrough EXTERNAL deps (Prisma raw shape) ─────────────────
+// ── Sub-mappers: passthrough EXTERNAL deps (clean views) ──────────────────────
 
 export function toContactSummary(
-  contact: ContactRaw,
+  contact: ContactView,
 ): PurchaseWithDetails["contact"] {
   return {
     id: contact.id,
@@ -140,7 +140,7 @@ export function toContactSummary(
   };
 }
 
-export function toPeriodSummary(period: PeriodRaw): PurchaseWithDetails["period"] {
+export function toPeriodSummary(period: PeriodView): PurchaseWithDetails["period"] {
   return {
     id: period.id,
     name: period.name,
@@ -148,14 +148,14 @@ export function toPeriodSummary(period: PeriodRaw): PurchaseWithDetails["period"
   };
 }
 
-// ── Sub-mapper: payable Decimal→number + nested allocations + payment ─────────
+// ── Sub-mapper: payable clean numbers + nested allocations + payment ──────────
 
-export function toPayableSummary(payable: PayableRaw): PayableSummary {
+export function toPayableSummary(payable: PayableView): PayableSummary {
   return {
     id: payable.id,
-    amount: payable.amount.toNumber(),
-    paid: payable.paid.toNumber(),
-    balance: payable.balance.toNumber(),
+    amount: payable.amount,
+    paid: payable.paid,
+    balance: payable.balance,
     status: payable.status,
     dueDate: payable.dueDate,
     allocations: payable.allocations.map(toPaymentAllocationSummary),
@@ -163,12 +163,12 @@ export function toPayableSummary(payable: PayableRaw): PayableSummary {
 }
 
 function toPaymentAllocationSummary(
-  allocation: AllocationRaw,
+  allocation: AllocationView,
 ): PaymentAllocationSummary {
   return {
     id: allocation.id,
     paymentId: allocation.paymentId,
-    amount: allocation.amount.toNumber(),
+    amount: allocation.amount,
     payment: {
       id: allocation.payment.id,
       date: allocation.payment.date.toISOString(),

--- a/modules/sale/domain/ports/sale-contact-reader.port.ts
+++ b/modules/sale/domain/ports/sale-contact-reader.port.ts
@@ -1,0 +1,29 @@
+/**
+ * Read port for the sale's contact summary as consumed by the sale detail
+ * page (sale-pure-read pilot). Sale-hex declares this port instead of the
+ * page querying Prisma directly so the presentation layer stays decoupled
+ * from persistence (R2 §3 ports-only) and the read is tenant-scoped.
+ *
+ * The view is a clean DTO — plain values only, NO Prisma types. The Prisma
+ * projection→view conversion lives in the infrastructure adapter
+ * (`PrismaSaleContactReaderAdapter`).
+ */
+
+export interface SaleContactView {
+  id: string;
+  name: string;
+  type: string;
+  nit: string | null;
+  paymentTermsDays: number | null;
+}
+
+export interface SaleContactReaderPort {
+  /**
+   * Returns the contact summary for a sale, or null when no contact matches
+   * the id within the organization (cross-tenant reads resolve to null).
+   */
+  findById(
+    organizationId: string,
+    contactId: string,
+  ): Promise<SaleContactView | null>;
+}

--- a/modules/sale/domain/ports/sale-receivable-reader.port.ts
+++ b/modules/sale/domain/ports/sale-receivable-reader.port.ts
@@ -1,0 +1,46 @@
+/**
+ * Read port for the sale's receivable-with-allocations as consumed by the
+ * sale detail page (sale-pure-read pilot). Sale-hex declares this port
+ * instead of the page querying Prisma directly so the presentation layer
+ * stays decoupled from persistence (R2 §3 ports-only) and the read is
+ * tenant-scoped.
+ *
+ * The view is a clean DTO — monetary fields are plain `number`, NO
+ * `Prisma.Decimal` leaks into the domain. The Decimal→number conversion is
+ * an infrastructure boundary concern (`PrismaSaleReceivableReaderAdapter`).
+ * Allocations arrive ordered by payment date ascending (adapter contract —
+ * mirrors the legacy page query `orderBy: { payment: { date: "asc" } }`).
+ */
+
+export interface SalePaymentAllocationView {
+  id: string;
+  paymentId: string;
+  amount: number;
+  payment: {
+    id: string;
+    date: Date;
+    description: string;
+  };
+}
+
+export interface SaleReceivableView {
+  id: string;
+  amount: number;
+  paid: number;
+  balance: number;
+  status: string;
+  dueDate: Date;
+  allocations: SalePaymentAllocationView[];
+}
+
+export interface SaleReceivableReaderPort {
+  /**
+   * Returns the receivable with its payment allocations (ordered by payment
+   * date asc), or null when no receivable matches the id within the
+   * organization (cross-tenant reads resolve to null).
+   */
+  findWithAllocations(
+    organizationId: string,
+    receivableId: string,
+  ): Promise<SaleReceivableView | null>;
+}

--- a/modules/sale/infrastructure/__tests__/prisma-sale-contact-reader.adapter.test.ts
+++ b/modules/sale/infrastructure/__tests__/prisma-sale-contact-reader.adapter.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for PrismaSaleContactReaderAdapter (sale-pure-read pilot).
+ *
+ * Mocks @/lib/prisma to avoid DB dependency — mirror
+ * `modules/accounting/infrastructure/__tests__/prisma-accounts.repo.unit.test.ts`
+ * mock pattern. Covers: query shape (tenant-scoped `findFirst` where + select
+ * projection), clean-view passthrough, and null branch.
+ *
+ * RED acceptance failure mode: FAILS pre-implementación por module resolution
+ * failure (`PrismaSaleContactReaderAdapter` no existe). Post-GREEN: PASSES
+ * porque el adapter emite el where {id, organizationId} + select projection y
+ * retorna el row (shape ya limpio — no hay Decimal en la projection contact).
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    contact: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@/lib/prisma";
+import { PrismaSaleContactReaderAdapter } from "../prisma-sale-contact-reader.adapter";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PrismaSaleContactReaderAdapter — findById", () => {
+  it("scopes the query by organizationId AND contact id (tenant safety) with the exact select projection", async () => {
+    vi.mocked(prisma.contact.findFirst).mockResolvedValueOnce(null);
+
+    const adapter = new PrismaSaleContactReaderAdapter();
+    await adapter.findById("org-1", "contact-1");
+
+    expect(prisma.contact.findFirst).toHaveBeenCalledTimes(1);
+    expect(prisma.contact.findFirst).toHaveBeenCalledWith({
+      where: { id: "contact-1", organizationId: "org-1" },
+      select: {
+        id: true,
+        name: true,
+        type: true,
+        nit: true,
+        paymentTermsDays: true,
+      },
+    });
+  });
+
+  it("returns the clean contact view when the row exists", async () => {
+    vi.mocked(prisma.contact.findFirst).mockResolvedValueOnce({
+      id: "contact-1",
+      name: "Cliente Uno",
+      type: "CLIENTE",
+      nit: "12345-6",
+      paymentTermsDays: 30,
+      // Cast: mock returns the select projection, not the full Contact row.
+    } as never);
+
+    const adapter = new PrismaSaleContactReaderAdapter();
+    const result = await adapter.findById("org-1", "contact-1");
+
+    expect(result).toEqual({
+      id: "contact-1",
+      name: "Cliente Uno",
+      type: "CLIENTE",
+      nit: "12345-6",
+      paymentTermsDays: 30,
+    });
+  });
+
+  it("returns null when no contact matches id + organizationId (cross-tenant or missing)", async () => {
+    vi.mocked(prisma.contact.findFirst).mockResolvedValueOnce(null);
+
+    const adapter = new PrismaSaleContactReaderAdapter();
+    const result = await adapter.findById("org-other", "contact-1");
+
+    expect(result).toBeNull();
+  });
+});

--- a/modules/sale/infrastructure/__tests__/prisma-sale-receivable-reader.adapter.test.ts
+++ b/modules/sale/infrastructure/__tests__/prisma-sale-receivable-reader.adapter.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for PrismaSaleReceivableReaderAdapter (sale-pure-read pilot).
+ *
+ * Mocks @/lib/prisma to avoid DB dependency — mirror
+ * `modules/accounting/infrastructure/__tests__/prisma-accounts.repo.unit.test.ts`
+ * mock pattern. Covers: query shape (tenant-scoped `findFirst` where + nested
+ * allocations select ordered by payment.date asc), Decimal→number boundary
+ * conversion (port must NOT leak Prisma.Decimal), and null branch.
+ *
+ * Decimal mocking: `{ toNumber: () => n }` cast — same technique as
+ * `sale-to-with-details.mapper.test.ts` fakeDecimal (no runtime Decimal
+ * value import).
+ *
+ * RED acceptance failure mode: FAILS pre-implementación por module resolution
+ * failure (`PrismaSaleReceivableReaderAdapter` no existe). Post-GREEN: PASSES
+ * porque el adapter emite el where {id, organizationId}, la projection nested
+ * con orderBy payment.date asc, y convierte amount/paid/balance/allocations
+ * amount de Decimal a number en el boundary infrastructure.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Prisma } from "@/generated/prisma/client";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    accountsReceivable: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@/lib/prisma";
+import { PrismaSaleReceivableReaderAdapter } from "../prisma-sale-receivable-reader.adapter";
+
+const fakeDecimal = (n: number): Prisma.Decimal =>
+  ({ toNumber: () => n }) as unknown as Prisma.Decimal;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PrismaSaleReceivableReaderAdapter — findWithAllocations", () => {
+  it("scopes the query by organizationId AND receivable id with nested allocations ordered by payment.date asc", async () => {
+    vi.mocked(prisma.accountsReceivable.findFirst).mockResolvedValueOnce(null);
+
+    const adapter = new PrismaSaleReceivableReaderAdapter();
+    await adapter.findWithAllocations("org-1", "rec-1");
+
+    expect(prisma.accountsReceivable.findFirst).toHaveBeenCalledTimes(1);
+    expect(prisma.accountsReceivable.findFirst).toHaveBeenCalledWith({
+      where: { id: "rec-1", organizationId: "org-1" },
+      select: {
+        id: true,
+        amount: true,
+        paid: true,
+        balance: true,
+        status: true,
+        dueDate: true,
+        allocations: {
+          select: {
+            id: true,
+            paymentId: true,
+            amount: true,
+            payment: {
+              select: { id: true, date: true, description: true },
+            },
+          },
+          orderBy: { payment: { date: "asc" } },
+        },
+      },
+    });
+  });
+
+  it("converts Decimal fields (amount/paid/balance + allocation amounts) to plain numbers — no Prisma.Decimal leaks", async () => {
+    const paymentDate = new Date("2026-03-15T10:00:00Z");
+    vi.mocked(prisma.accountsReceivable.findFirst).mockResolvedValueOnce({
+      id: "rec-1",
+      amount: fakeDecimal(150),
+      paid: fakeDecimal(50),
+      balance: fakeDecimal(100),
+      status: "PARTIAL",
+      dueDate: new Date("2026-04-30"),
+      allocations: [
+        {
+          id: "alloc-1",
+          paymentId: "pay-1",
+          amount: fakeDecimal(50),
+          payment: {
+            id: "pay-1",
+            date: paymentDate,
+            description: "Pago parcial",
+          },
+        },
+      ],
+      // Cast: mock returns the select projection, not the full row.
+    } as never);
+
+    const adapter = new PrismaSaleReceivableReaderAdapter();
+    const result = await adapter.findWithAllocations("org-1", "rec-1");
+
+    expect(result).toEqual({
+      id: "rec-1",
+      amount: 150,
+      paid: 50,
+      balance: 100,
+      status: "PARTIAL",
+      dueDate: new Date("2026-04-30"),
+      allocations: [
+        {
+          id: "alloc-1",
+          paymentId: "pay-1",
+          amount: 50,
+          payment: {
+            id: "pay-1",
+            date: paymentDate,
+            description: "Pago parcial",
+          },
+        },
+      ],
+    });
+    // Plain numbers, not Decimal-like objects.
+    expect(typeof result!.amount).toBe("number");
+    expect(typeof result!.allocations[0].amount).toBe("number");
+  });
+
+  it("returns null when no receivable matches id + organizationId (cross-tenant or missing)", async () => {
+    vi.mocked(prisma.accountsReceivable.findFirst).mockResolvedValueOnce(null);
+
+    const adapter = new PrismaSaleReceivableReaderAdapter();
+    const result = await adapter.findWithAllocations("org-other", "rec-1");
+
+    expect(result).toBeNull();
+  });
+});

--- a/modules/sale/infrastructure/prisma-sale-contact-reader.adapter.ts
+++ b/modules/sale/infrastructure/prisma-sale-contact-reader.adapter.ts
@@ -1,0 +1,40 @@
+import "server-only";
+import type { PrismaClient } from "@/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+import type {
+  SaleContactReaderPort,
+  SaleContactView,
+} from "@/modules/sale/domain/ports/sale-contact-reader.port";
+
+/**
+ * Prisma directo adapter for `SaleContactReaderPort` (sale-pure-read pilot).
+ * Mirror the legacy sales/[saleId] page `prisma.contact.findUnique` select
+ * projection, upgraded to `findFirst` with `{ id, organizationId }` where for
+ * tenant scoping (paridad `PrismaSaleRepository.findById`).
+ *
+ * Constructor flexible: `db = prisma` default — paridad con
+ * `PrismaSaleRepository`.
+ */
+
+type DbClient = Pick<PrismaClient, "contact">;
+
+export class PrismaSaleContactReaderAdapter implements SaleContactReaderPort {
+  constructor(private readonly db: DbClient = prisma) {}
+
+  async findById(
+    organizationId: string,
+    contactId: string,
+  ): Promise<SaleContactView | null> {
+    const row = await this.db.contact.findFirst({
+      where: { id: contactId, organizationId },
+      select: {
+        id: true,
+        name: true,
+        type: true,
+        nit: true,
+        paymentTermsDays: true,
+      },
+    });
+    return row;
+  }
+}

--- a/modules/sale/infrastructure/prisma-sale-receivable-reader.adapter.ts
+++ b/modules/sale/infrastructure/prisma-sale-receivable-reader.adapter.ts
@@ -1,0 +1,77 @@
+import "server-only";
+import type { PrismaClient } from "@/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+import type {
+  SaleReceivableReaderPort,
+  SaleReceivableView,
+} from "@/modules/sale/domain/ports/sale-receivable-reader.port";
+
+/**
+ * Prisma directo adapter for `SaleReceivableReaderPort` (sale-pure-read
+ * pilot). Mirror the legacy sales/[saleId] page
+ * `prisma.accountsReceivable.findUnique` select projection (nested
+ * allocations + payment ordered by payment.date asc), upgraded to `findFirst`
+ * with `{ id, organizationId }` where for tenant scoping (paridad
+ * `PrismaSaleRepository.findById`).
+ *
+ * Decimal→number conversion happens HERE (infrastructure boundary) so the
+ * port view never leaks `Prisma.Decimal` into domain/presentation.
+ *
+ * Constructor flexible: `db = prisma` default — paridad con
+ * `PrismaSaleRepository`.
+ */
+
+type DbClient = Pick<PrismaClient, "accountsReceivable">;
+
+export class PrismaSaleReceivableReaderAdapter
+  implements SaleReceivableReaderPort
+{
+  constructor(private readonly db: DbClient = prisma) {}
+
+  async findWithAllocations(
+    organizationId: string,
+    receivableId: string,
+  ): Promise<SaleReceivableView | null> {
+    const row = await this.db.accountsReceivable.findFirst({
+      where: { id: receivableId, organizationId },
+      select: {
+        id: true,
+        amount: true,
+        paid: true,
+        balance: true,
+        status: true,
+        dueDate: true,
+        allocations: {
+          select: {
+            id: true,
+            paymentId: true,
+            amount: true,
+            payment: {
+              select: { id: true, date: true, description: true },
+            },
+          },
+          orderBy: { payment: { date: "asc" as const } },
+        },
+      },
+    });
+    if (!row) return null;
+    return {
+      id: row.id,
+      amount: row.amount.toNumber(),
+      paid: row.paid.toNumber(),
+      balance: row.balance.toNumber(),
+      status: row.status,
+      dueDate: row.dueDate,
+      allocations: row.allocations.map((allocation) => ({
+        id: allocation.id,
+        paymentId: allocation.paymentId,
+        amount: allocation.amount.toNumber(),
+        payment: {
+          id: allocation.payment.id,
+          date: allocation.payment.date,
+          description: allocation.payment.description,
+        },
+      })),
+    };
+  }
+}

--- a/modules/sale/presentation/__tests__/c4a-cutover-shape.poc-nuevo-a3.test.ts
+++ b/modules/sale/presentation/__tests__/c4a-cutover-shape.poc-nuevo-a3.test.ts
@@ -101,11 +101,16 @@ describe("POC nuevo A3-C4a — cutover sales/page.tsx list view shape", () => {
     );
   });
 
-  it("Test 3: sales/page.tsx imports `prisma` from `@/lib/prisma` (Prisma direct batch lookups Q4)", () => {
+  // Test 3 FLIPPED (list-pages-pure-read Group C): original assertion locked
+  // the Q4 Prisma-direct batch-lookup pattern (`prisma` import PRESENT). That
+  // lock is SUPERSEDED — the batch hydrations moved behind the EXISTING
+  // contacts + fiscal-periods module services (no new read ports; architect
+  // rule: reuse, no ceremony for dumb lookups). Assertion inverted: prisma
+  // import must now be ABSENT. Positive counterpart lives in
+  // app/(dashboard)/[orgSlug]/sales/__tests__/page-hex-purity.test.ts.
+  it("Test 3 (flipped): sales/page.tsx does NOT import `prisma` from `@/lib/prisma` (list-pages-pure-read supersedes Q4)", () => {
     const source = fs.readFileSync(SALES_PAGE_PATH, "utf8");
-    expect(source).toMatch(
-      /import\s*\{[^}]*\bprisma\b[^}]*\}\s*from\s*["']@\/lib\/prisma["']/,
-    );
+    expect(source).not.toMatch(/["']@\/lib\/prisma["']/);
   });
 
   // ── Tests 4-6 negative: legacy ausentes ─────────────────────────────────────

--- a/modules/sale/presentation/__tests__/c4b-cutover-shape.poc-nuevo-a3.test.ts
+++ b/modules/sale/presentation/__tests__/c4b-cutover-shape.poc-nuevo-a3.test.ts
@@ -47,6 +47,15 @@
  *   - Test 6 negative: `@/features/sale` exact root barrel ABSENT (regex
  *     anchored — preserva imports legítimos deep paths future-proof)
  *
+ * SUPERSEDED (sale-pure-read pilot): Marco lock Q4 (Prisma direct deps
+ * lookups en page) fue reemplazado — los 2 reads (contact +
+ * receivable+allocations) viven detrás de read ports del sale module
+ * (`SaleContactReaderPort` / `SaleReceivableReaderPort`) expuestos via
+ * `makeSaleReads()`. Test 3 flipped: ahora asserta `makeSaleReads` import
+ * PRESENT + `@/lib/prisma` import ABSENT (page pure hexagonal). Ver
+ * `app/(dashboard)/[orgSlug]/sales/[saleId]/__tests__/page-hex-purity.test.ts`
+ * (sentinel dedicado del pilot).
+ *
  * GREEN A3-C4b single commit β (mirror precedent A3-C4a + A3-C2 atomic batch):
  *   - Modify `app/(dashboard)/[orgSlug]/sales/[saleId]/page.tsx`:
  *     · Replace `new SaleService()` con `makeSaleService()`
@@ -102,11 +111,12 @@ describe("POC nuevo A3-C4b — cutover sales/[saleId]/page.tsx detail view shape
     );
   });
 
-  it("Test 3: sales/[saleId]/page.tsx imports `prisma` from `@/lib/prisma` (Prisma direct deps lookups Q4)", () => {
+  it("Test 3: sales/[saleId]/page.tsx imports `makeSaleReads` (read ports) and does NOT import `@/lib/prisma` (sale-pure-read pilot supersedes Q4)", () => {
     const source = fs.readFileSync(SALE_DETAIL_PAGE_PATH, "utf8");
     expect(source).toMatch(
-      /import\s*\{[^}]*\bprisma\b[^}]*\}\s*from\s*["']@\/lib\/prisma["']/,
+      /import\s*\{[^}]*\bmakeSaleReads\b[^}]*\}\s*from\s*["']@\/modules\/sale\/presentation\/composition-root["']/,
     );
+    expect(source).not.toMatch(/["']@\/lib\/prisma["']/);
   });
 
   // ── Tests 4-6 negative: legacy ausentes ─────────────────────────────────────

--- a/modules/sale/presentation/composition-root.ts
+++ b/modules/sale/presentation/composition-root.ts
@@ -13,9 +13,13 @@ import { PrismaOperationalDocTypesRepository } from "@/modules/operational-doc-t
 import { makeReceivablesRepository } from "@/modules/receivables/presentation/server";
 import type { UnitOfWorkRepoLike } from "@/modules/shared/infrastructure/prisma-unit-of-work";
 
+import type { SaleContactReaderPort } from "../domain/ports/sale-contact-reader.port";
+import type { SaleReceivableReaderPort } from "../domain/ports/sale-receivable-reader.port";
 import { SaleService } from "../application/sale.service";
 import { LegacySalePermissionsAdapter } from "../infrastructure/legacy-sale-permissions.adapter";
 import { PrismaOrgSettingsReaderAdapter } from "../infrastructure/prisma-org-settings-reader.adapter";
+import { PrismaSaleContactReaderAdapter } from "../infrastructure/prisma-sale-contact-reader.adapter";
+import { PrismaSaleReceivableReaderAdapter } from "../infrastructure/prisma-sale-receivable-reader.adapter";
 import { PrismaSaleRepository } from "../infrastructure/prisma-sale.repository";
 import { PrismaSaleUnitOfWork } from "../infrastructure/prisma-sale-unit-of-work";
 
@@ -54,6 +58,24 @@ const accountLookupAdapter = new LegacyAccountLookupAdapter(accountsRepo);
 // injected into the sale UoW so the per-tx PrismaJournalEntryFactoryAdapter
 // resolves VG / FL / PF / CG / SV via findByCode at JE creation.
 const operationalDocTypesRepo = new PrismaOperationalDocTypesRepository();
+
+/**
+ * Read facade for sale detail page external deps (sale-pure-read pilot) —
+ * groups the tenant-scoped read ports the page consumes instead of querying
+ * Prisma directly. Wiring lives here (único archivo bajo `presentation/`
+ * autorizado a importar de `infrastructure/` — architecture.md R4 carve-out).
+ */
+export interface SaleReads {
+  contact: SaleContactReaderPort;
+  receivable: SaleReceivableReaderPort;
+}
+
+export function makeSaleReads(): SaleReads {
+  return {
+    contact: new PrismaSaleContactReaderAdapter(),
+    receivable: new PrismaSaleReceivableReaderAdapter(),
+  };
+}
 
 export function makeSaleService(): SaleService {
   return new SaleService({

--- a/modules/sale/presentation/mappers/__tests__/sale-to-with-details.mapper.test.ts
+++ b/modules/sale/presentation/mappers/__tests__/sale-to-with-details.mapper.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it } from "vitest";
 
-import type { Prisma } from "@/generated/prisma/client";
-
 import { Sale } from "@/modules/sale/domain/sale.entity";
 import { SaleDetail } from "@/modules/sale/domain/sale-detail.entity";
 import { MonetaryAmount } from "@/modules/shared/domain/value-objects/monetary-amount";
@@ -23,19 +21,18 @@ import {
  * Test 8 composite modificado (sin createdBy en deps + result assertion):
  *   1. computeDisplayCode happy path VG-NNN padStart 3 (mirror legacy getDisplayCode)
  *   2. computeDisplayCode null edge throws (SubQ-d fail-fast — DRAFT sales)
- *   3. toContactSummary passthrough Prisma raw → DTO contact shape
- *   4. toPeriodSummary passthrough Prisma raw → DTO period shape
- *   5. toReceivableSummary Decimal→number + nested allocations + payment.date toISOString
+ *   3. toContactSummary passthrough clean view → DTO contact shape
+ *   4. toPeriodSummary passthrough clean view → DTO period shape
+ *   5. toReceivableSummary clean numbers passthrough + nested allocations + payment.date toISOString
  *   6. toSaleDetailRow MonetaryAmount→number + quantity/unitPrice undefined→null
  *   7. toSaleWithDetails main compositor caller-passes-deps Sale entity + deps → SaleWithDetails end-to-end
  *
- * Decimal mocking: type-only `import type { Prisma }` + cast to satisfy
- * `.toNumber()` interface (R5 banPrismaInPresentation preserved — no runtime
- * Decimal value import; A3-C1.5 §13.V carve-out allowTypeImports: true).
+ * Sale-pure-read pilot: deps ya NO llegan como Prisma raw con Decimal — el
+ * caller (page) los carga via read ports (`SaleContactReaderPort` /
+ * `SaleReceivableReaderPort`) cuyos adapters convierten Decimal→number en el
+ * boundary infrastructure. El mapper consume shapes limpios (numbers) y NO
+ * importa Prisma ni siquiera type-only.
  */
-
-const fakeDecimal = (n: number): Prisma.Decimal =>
-  ({ toNumber: () => n }) as unknown as Prisma.Decimal;
 
 describe("sale-to-with-details mappers (smoke)", () => {
   // Tests 1 + 2 (computeDisplayCode happy path + null edge) RETIRED per
@@ -43,7 +40,7 @@ describe("sale-to-with-details mappers (smoke)", () => {
 
   // ── Test 3: toContactSummary passthrough ──────────────────────────────────────
 
-  it("toContactSummary passthrough Prisma raw → DTO contact shape", () => {
+  it("toContactSummary passthrough clean view → DTO contact shape", () => {
     const contact = {
       id: "c-1",
       name: "Cliente Uno",
@@ -59,27 +56,27 @@ describe("sale-to-with-details mappers (smoke)", () => {
 
   // ── Test 4: toPeriodSummary passthrough ───────────────────────────────────────
 
-  it("toPeriodSummary passthrough Prisma raw → DTO period shape", () => {
+  it("toPeriodSummary passthrough clean view → DTO period shape", () => {
     const period = { id: "p-1", name: "Enero 2026", status: "OPEN" };
     expect(toPeriodSummary(period)).toEqual(period);
   });
 
-  // ── Test 5: toReceivableSummary Decimal→number + nested allocations ───────────
+  // ── Test 5: toReceivableSummary clean numbers + nested allocations ────────────
 
-  it("toReceivableSummary Decimal→number + nested allocations + payment.date toISOString", () => {
+  it("toReceivableSummary clean numbers passthrough + nested allocations + payment.date toISOString", () => {
     const paymentDate = new Date("2026-03-15T10:00:00Z");
     const receivable = {
       id: "r-1",
-      amount: fakeDecimal(150),
-      paid: fakeDecimal(50),
-      balance: fakeDecimal(100),
+      amount: 150,
+      paid: 50,
+      balance: 100,
       status: "PARTIAL",
       dueDate: new Date("2026-04-30"),
       allocations: [
         {
           id: "a-1",
           paymentId: "pay-1",
-          amount: fakeDecimal(50),
+          amount: 50,
           payment: {
             id: "pay-1",
             date: paymentDate,

--- a/modules/sale/presentation/mappers/sale-to-with-details.mapper.ts
+++ b/modules/sale/presentation/mappers/sale-to-with-details.mapper.ts
@@ -1,7 +1,5 @@
 import "server-only";
 
-import type { Prisma } from "@/generated/prisma/client";
-
 import type { Sale } from "../../domain/sale.entity";
 import type { SaleDetail } from "../../domain/sale-detail.entity";
 import type {
@@ -19,16 +17,16 @@ import type {
  * SaleServiceForHub interface. §13.T resolution preparation pre A3-C4 cutover
  * 2 sale pages + A3-C5 cutover 2 HubService deps.
  *
- * Pattern: caller (page) loads external deps via separate Prisma queries
- * (contact via ContactsService, period via FiscalPeriodsService, receivable via
- * Prisma direct, ivaSalesBook via Prisma direct) y pasa al main compositor
+ * Pattern: caller (page) loads external deps via services/read ports
+ * (contact + receivable via `makeSaleReads()` sale read ports, period via
+ * FiscalPeriodsService) y pasa al main compositor
  * `toSaleWithDetails(sale, deps)` que invoca sub-mappers cohesivos.
  *
  * Hex purity preserved: mapper consume Sale domain entity output (`makeSaleService`),
  * NO toca presentation concerns dentro de application layer. Sub-mappers
- * EXTERNAL deps (contact/period/receivable) reciben Prisma raw shape
- * passthrough (Marco lock GREEN — caller ya carga via Prisma queries, mapper
- * recibe directo).
+ * EXTERNAL deps (contact/period/receivable) reciben clean views desde los
+ * read ports (sale-pure-read pilot — los adapters Prisma convierten
+ * Decimal→number en el boundary infrastructure, mapper recibe numbers).
  *
  * §13.W resolution (A3-C3.5 paired follow-up): unused user-summary nested
  * field dropeado del mapper deps signature + DTO + sub-mapper export. Verified
@@ -42,10 +40,9 @@ import type {
  * Conversion MonetaryAmount→number + quantity/unitPrice undefined→null per
  * SaleDetailRow `number | null` shape.
  *
- * R5 banPrismaInPresentation preserved via type-only Prisma import (A3-C1.5
- * §13.V carve-out allowTypeImports: true). NO runtime Prisma value usage en
- * mapper module — Decimal.toNumber() invocado sobre instance ya construida
- * upstream por Prisma query (caller-side).
+ * R5 banPrismaInPresentation preserved — sale-pure-read pilot removed even the
+ * type-only Prisma import: deps arrive as clean views (plain numbers) from the
+ * sale read ports, so no `Prisma.Decimal` appears anywhere in this module.
  *
  * Cross-ref:
  * - architecture.md §13.T DTO shape divergence Sale entity vs SaleWithDetails
@@ -57,13 +54,16 @@ import type {
  * - modules/sale/application/sale.service.ts:94-105 (hex .list/.getById return Sale entity)
  */
 
-// ── Types: Prisma raw shapes mirror legacy `saleInclude` ───────────────────────
+// ── Types: clean external dep views (mirror legacy `saleInclude` fields) ───────
 //
-// External dep input shapes corresponden 1:1 a legacy `saleInclude` Prisma select
-// projections (legacy saleInclude — post-A3-C7 atomic delete). Caller carga estos
-// shapes via Prisma queries (typically con `select` matching estos fields).
+// External dep input shapes corresponden 1:1 a legacy `saleInclude` select
+// projections (post-A3-C7 atomic delete) PERO ya limpios: monetary fields son
+// `number` (sale-pure-read pilot — caller carga via `makeSaleReads()` read
+// ports cuyos adapters convierten Decimal→number en infrastructure).
+// Structural typing: `SaleContactView` / `SaleReceivableView` (domain ports)
+// satisfacen estos shapes sin acoplar el mapper a los ports.
 
-export type ContactRaw = {
+export type ContactView = {
   id: string;
   name: string;
   type: string;
@@ -71,16 +71,16 @@ export type ContactRaw = {
   paymentTermsDays?: number | null;
 };
 
-export type PeriodRaw = {
+export type PeriodView = {
   id: string;
   name: string;
   status: string;
 };
 
-export type AllocationRaw = {
+export type AllocationView = {
   id: string;
   paymentId: string;
-  amount: Prisma.Decimal;
+  amount: number;
   payment: {
     id: string;
     date: Date;
@@ -88,28 +88,28 @@ export type AllocationRaw = {
   };
 };
 
-export type ReceivableRaw = {
+export type ReceivableView = {
   id: string;
-  amount: Prisma.Decimal;
-  paid: Prisma.Decimal;
-  balance: Prisma.Decimal;
+  amount: number;
+  paid: number;
+  balance: number;
   status: string;
   dueDate: Date;
-  allocations: AllocationRaw[];
+  allocations: AllocationView[];
 };
 
 // ── Main mapper deps (caller-passes-deps signature) ────────────────────────────
 
 export interface ToSaleWithDetailsDeps {
-  contact: ContactRaw;
-  period: PeriodRaw;
-  receivable?: ReceivableRaw | null;
+  contact: ContactView;
+  period: PeriodView;
+  receivable?: ReceivableView | null;
 }
 
-// ── Sub-mappers: passthrough EXTERNAL deps (Prisma raw shape) ─────────────────
+// ── Sub-mappers: passthrough EXTERNAL deps (clean views) ──────────────────────
 
 export function toContactSummary(
-  contact: ContactRaw,
+  contact: ContactView,
 ): SaleWithDetails["contact"] {
   return {
     id: contact.id,
@@ -120,7 +120,7 @@ export function toContactSummary(
   };
 }
 
-export function toPeriodSummary(period: PeriodRaw): SaleWithDetails["period"] {
+export function toPeriodSummary(period: PeriodView): SaleWithDetails["period"] {
   return {
     id: period.id,
     name: period.name,
@@ -128,16 +128,16 @@ export function toPeriodSummary(period: PeriodRaw): SaleWithDetails["period"] {
   };
 }
 
-// ── Sub-mapper: receivable Decimal→number + nested allocations + payment ───────
+// ── Sub-mapper: receivable clean numbers + nested allocations + payment ────────
 
 export function toReceivableSummary(
-  receivable: ReceivableRaw,
+  receivable: ReceivableView,
 ): ReceivableSummary {
   return {
     id: receivable.id,
-    amount: receivable.amount.toNumber(),
-    paid: receivable.paid.toNumber(),
-    balance: receivable.balance.toNumber(),
+    amount: receivable.amount,
+    paid: receivable.paid,
+    balance: receivable.balance,
     status: receivable.status,
     dueDate: receivable.dueDate,
     allocations: receivable.allocations.map(toPaymentAllocationSummary),
@@ -145,12 +145,12 @@ export function toReceivableSummary(
 }
 
 function toPaymentAllocationSummary(
-  allocation: AllocationRaw,
+  allocation: AllocationView,
 ): PaymentAllocationSummary {
   return {
     id: allocation.id,
     paymentId: allocation.paymentId,
-    amount: allocation.amount.toNumber(),
+    amount: allocation.amount,
     payment: {
       id: allocation.payment.id,
       date: allocation.payment.date.toISOString(),


### PR DESCRIPTION
## Summary
- Presentation layer (`app/`, `components/`, `lib/`) is now **100% prisma-free** — zero `@/lib/prisma` imports outside `modules/`.
- Every direct Prisma read in pages/routes now goes through a module-owned **read port** (hexagonal), or reuses an existing module service for dumb lookups.
- Free tenant-safety upgrade: unscoped `findUnique({ id })` → `findFirst({ id, organizationId })`.

## Changes
| Area | Change |
|------|--------|
| `sale`, `purchase` detail pages | new `{Contact,Receivable/Payable}ReaderPort` + prisma adapters via `make{Sale,Purchase}Reads()` |
| `audit` trio (page, close-event, audit-trail route) | `AuditCloseEventReaderPort` + `AuditOrgMembersReaderPort` via `makeAuditReads()` |
| `sales`/`purchases` list pages | reuse existing `contacts` + `fiscal-periods` services (no new ports) |
| mappers | `Decimal→number` moved to infra boundary; `Raw` types renamed to `View`; Prisma import dropped |
| tests | added `page-hex-purity` sentinels; flipped superseded poc-nuevo prisma-lock tests |

## Test Plan
- [x] `pnpm exec tsc --noEmit` → exit 0
- [x] `pnpm test` → 805 files / 7362 tests passed (full suite, all change-sets combined)
- [x] grep proof: 7 targets + full `app`/`components`/`lib` rescan → zero prisma imports outside `modules/`